### PR TITLE
Fix for missing breakout/stopLoss

### DIFF
--- a/scanner.js
+++ b/scanner.js
@@ -119,6 +119,15 @@ export async function analyzeCandles(
 
     if (!pattern) return null;
 
+    // Fallback breakout/stopLoss if missing
+    if (typeof pattern.breakout !== "number" || isNaN(pattern.breakout)) {
+      pattern.breakout = last.close;
+    }
+    if (typeof pattern.stopLoss !== "number" || isNaN(pattern.stopLoss)) {
+      pattern.stopLoss =
+        pattern.direction === "Long" ? last.low : last.high;
+    }
+
     if (
       (pattern.direction === "Long" && rsi > 75) ||
       (pattern.direction === "Short" && rsi < 25)


### PR DESCRIPTION
## Summary
- provide fallback breakout and stoploss values if a pattern omits them

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_685e272e0f04832e9cca50d987384aa5