### PR TITLE
Fix confidence display in Telegram alerts

### DIFF
--- a/telegram.js
+++ b/telegram.js
@@ -32,7 +32,7 @@ export function sendSignal(signal) {
     `🎯 *Entry:* ${entry}\n` +
     `🛑 *Stop Loss:* ${stopLoss}\n` +
     `🎯 *Targets:* T1: ${target1} | T2: ${target2}\n` +
-    `📊 *Confidence Level:* ${confidence}/10\n\n` +
+    `📊 *Confidence Level:* ${confidence}\n\n` +
     `🕒 _Stay sharp. Market conditions may change quickly._`;
 
   bot


### PR DESCRIPTION
## Summary
- show confidence as 'High', 'Medium', or 'Low' instead of numeric scale

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_686035122a88832eb4a47bd949b2250e