### PR TITLE
Add advanced signal format using strategy engine

### DIFF
--- a/telegram.js
+++ b/telegram.js
@@ -20,8 +20,15 @@ export function sendSignal(signal) {
     return;
   }
 
-  const { stock, direction, entry, stopLoss, target1, target2, confidence } =
-    signal;
+  const data = signal.algoSignal || signal;
+  const stock = signal.stock || data.symbol;
+  const direction =
+    signal.direction || (data.side === "buy" ? "Long" : "Short");
+  const entry = signal.entry || data.entry;
+  const stopLoss = signal.stopLoss || data.stopLoss;
+  const target1 = signal.target1 || (data.targets ? data.targets[0] : null);
+  const target2 = signal.target2 || (data.targets ? data.targets[1] : null);
+  const confidence = signal.confidence || data.confidenceScore;
   const formattedDirection =
     direction === "Long" ? "🟢 Long Bias" : "🔴 Short Bias";
 


### PR DESCRIPTION
## Summary
- integrate `evaluateStrategies` into scanner
- calculate relative volume and create advanced signal structure
- update Telegram notifications to support new format

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686036a3a024832eaaf088956a6cfb25