### PR TITLE
Implement signal lifecycle management

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ import { sendSignal } from "./telegram.js";
 import { fetchAIData } from "./openAI.js";
 import db from "./db.js";
 import { Console } from "console";
+import { addSignal } from "./signalManager.js";
 
 const app = express();
 const server = http.createServer(app);
@@ -240,6 +241,7 @@ app.post("/candles", async (req, res) => {
       console.log("🚀 Emitting tradeSignal:", signal);
       io.emit("tradeSignal", signal);
       sendSignal(signal); // Send signal to Telegram
+      addSignal(signal);
       // Fetch AI details without blocking response
       fetchAIData(signal)
         .then((ai) => {

--- a/kite.js
+++ b/kite.js
@@ -8,6 +8,7 @@ import { fileURLToPath } from "url";
 import { ObjectId } from "mongodb";
 import { sendSignal } from "./telegram.js";
 import { fetchAIData } from "./openAI.js";
+import { addSignal } from "./signalManager.js";
 dotenv.config();
 
 import db from "./db.js"; // 🧠 Import database module for future use
@@ -378,6 +379,7 @@ export async function processAlignedCandles(io) {
             io.emit("tradeSignal", signal);
             logTrade(signal);
             sendSignal(signal); // 🐦 Send to Telegram
+            addSignal(signal);
             // STORE THE LATEST SIGNAL IN DB LATEST SIGNAL ON TOP
 
             const { insertedId } = await db.collection("signals").insertOne(signal);

--- a/telegram.js
+++ b/telegram.js
@@ -46,3 +46,8 @@ export function sendSignal(signal) {
     .sendMessage(chatId, text, { parse_mode: "Markdown" })
     .catch((err) => console.error("Telegram send error", err));
 }
+
+export function sendNotification(message) {
+  if (!bot || !chatId) return;
+  bot.sendMessage(chatId, message).catch((err) => console.error("Telegram send error", err));
+}

--- a/tests/analyzeCandles.test.js
+++ b/tests/analyzeCandles.test.js
@@ -1,5 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+process.env.NODE_ENV = 'test';
 
 const kiteMock = test.mock.module('../kite.js', {
   namedExports: {
@@ -19,6 +20,7 @@ const utilMock = test.mock.module('../util.js', {
     calculateVWAP: () => 100,
     getMAForSymbol: () => 100,
     getATR: () => 2.5,
+    calculateExpiryMinutes: () => 10,
     debounceSignal: () => true,
     detectAllPatterns: () => [
       {
@@ -65,6 +67,7 @@ test('analyzeCandles returns a signal for valid data', async () => {
   assert.ok(signal);
   assert.equal(signal.stock, 'TEST');
   assert.equal(signal.pattern, 'Breakout');
+  assert.ok(signal.expiresAt);
   kiteMock.restore();
   utilMock.restore();
   dbMock.restore();

--- a/tests/basic.test.js
+++ b/tests/basic.test.js
@@ -1,5 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+process.env.NODE_ENV = 'test';
 
 test('basic arithmetic', () => {
   assert.strictEqual(1 + 1, 2);

--- a/tests/candlesRoute.test.js
+++ b/tests/candlesRoute.test.js
@@ -1,5 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+process.env.NODE_ENV = 'test';
 import express from 'express';
 import { EventEmitter } from 'node:events';
 

--- a/tests/db.test.js
+++ b/tests/db.test.js
@@ -1,5 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+process.env.NODE_ENV = 'test';
 
 process.env.DB_USER_NAME = 'u';
 process.env.DB_PASSWORD = 'p';

--- a/tests/positionSizing.test.js
+++ b/tests/positionSizing.test.js
@@ -1,5 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+process.env.NODE_ENV = 'test';
 
 import { calculatePositionSize } from '../positionSizing.js';
 

--- a/tests/signalLifecycle.test.js
+++ b/tests/signalLifecycle.test.js
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { addSignal, activeSignals, checkExpiries } from '../signalManager.js';
+process.env.NODE_ENV = 'test';
+
+activeSignals.clear();
+
+const now = Date.now();
+const signal = { stock: 'TEST', direction: 'Long', expiresAt: new Date(now + 1000).toISOString(), confidence: 1 };
+
+addSignal(signal);
+
+checkExpiries(now + 2000);
+
+test('signal expires after expiry time', () => {
+  const info = activeSignals.get('TEST');
+  assert.equal(info.status, 'expired');
+});

--- a/util.js
+++ b/util.js
@@ -100,6 +100,13 @@ export function debounceSignal(
   return true;
 }
 
+export function calculateExpiryMinutes({ atr, rvol }) {
+  const base = 5;
+  const atrFactor = atr ? Math.min(Math.max(atr, 1), 4) : 1;
+  const volumeFactor = rvol && rvol > 1 ? 1 + Math.min(rvol - 1, 1) : 1;
+  return base * atrFactor * volumeFactor;
+}
+
 // export function detectAllPatterns(candles, atrValue, lookback = 5) {
 //   const patterns = [];
 //   if (candles.length < lookback) return [];


### PR DESCRIPTION
## Summary
- add dynamic expiry calculation in util
- compute expiry in scanner signals and mark them active
- manage signal states in new signalManager module
- notify telegram bot on expiry or conflicts
- integrate lifecycle manager in index and kite pipelines
- update tests for new behaviour and add lifecycle coverage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686043ca5f7c832e823acfe7e80221e4