### PR TITLE
Integrate intraday data usage

### DIFF
--- a/backtest.js
+++ b/backtest.js
@@ -29,7 +29,11 @@ for (const inst of instruments) {
 // const sessionData = JSON.parse(
 //   fs.readFileSync("./historical_data.json", "utf-8")
 // );
+const historicalSessionData = await db
+  .collection("historical_session_data")
+  .findOne({});
 const sessionData = await db.collection("session_data").findOne({});
+const combinedSessionData = { ...historicalSessionData, ...sessionData };
 
 // 🧠 CONFIG
 const SYMBOL = "NSE:ADANIENT";
@@ -42,13 +46,13 @@ const testDate = dayjs("20/6/2025", "D/M/YYYY");
 async function runBacktest(symbol = SYMBOL) {
   const token = symbolTokenMap[symbol];
 
-  if (!token || !sessionData[token]) {
+  if (!token || !combinedSessionData[token]) {
     console.error(`❌ No data found for symbol: ${symbol}`);
     return;
   }
 
   // ✅ Convert timestamps properly
-  const allCandles = sessionData[token].map((c) => ({
+  const allCandles = combinedSessionData[token].map((c) => ({
     open: c.open,
     high: c.high,
     low: c.low,

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ import {
   isMarketOpen,
   setStockSymbol,
   initSession,
+  fetchHistoricalIntradayData,
 } from "./kite.js";
 import { sendSignal } from "./telegram.js";
 import {
@@ -330,6 +331,18 @@ app.post("/set-interval", (req, res) => {
     res.json({ status: "Interval updated", interval });
   } else {
     res.status(400).json({ error: "Invalid interval" });
+  }
+});
+
+// Trigger historical intraday data fetch
+app.post("/fetch-intraday-data", async (req, res) => {
+  const { interval = "minute", days = 3 } = req.body || {};
+  try {
+    await fetchHistoricalIntradayData(interval, days);
+    res.json({ status: "success" });
+  } catch (err) {
+    console.error("❌ Intraday fetch error:", err.message);
+    res.status(500).json({ error: "Failed to fetch intraday data" });
   }
 });
 


### PR DESCRIPTION
## Summary
- load `historical_session_data` on startup
- expose `fetchHistoricalIntradayData` from `kite.js`
- allow triggering intraday fetch via `/fetch-intraday-data` endpoint
- combine intraday history when running backtests

## Testing
- `npm test` *(fails: Index setup failed db.collection is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68637804e93c8325a211f64c11c3dc7b