### PR TITLE
Integrate intraday history fetching

### DIFF
--- a/backtest.js
+++ b/backtest.js
@@ -43,7 +43,7 @@ const DELAY_MS = 10;
 // 🗓️ Set test date manually
 const testDate = dayjs("20/6/2025", "D/M/YYYY");
 
-async function runBacktest(symbol = SYMBOL) {
+export async function backtestStrategy(symbol = SYMBOL) {
   const token = symbolTokenMap[symbol];
 
   if (!token || !combinedSessionData[token]) {
@@ -152,4 +152,6 @@ async function runBacktest(symbol = SYMBOL) {
   );
 }
 
-runBacktest();
+if (process.env.NODE_ENV !== 'test') {
+  backtestStrategy();
+}


### PR DESCRIPTION
## Summary
- refresh intraday candles when live feed starts
- update candle history cache from MongoDB automatically
- ensure history exists before signal generation
- add simple volatility check in `checkRisk`
- expose support/resistance helper
- provide `backtestStrategy` for strategy evaluation

## Testing
- `node --test --test-reporter=tap` *(fails: test.mock.module is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_686381e0351083258782c462aca61e81