### PR TITLE
Integrate support/resistance utilities

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,8 @@ import {
   setStockSymbol,
   initSession,
   fetchHistoricalIntradayData,
+  getSupportResistanceLevels,
+  rebuildThreeMinCandlesFromOneMin,
 } from "./kite.js";
 import { sendSignal } from "./telegram.js";
 import {
@@ -343,6 +345,29 @@ app.post("/fetch-intraday-data", async (req, res) => {
   } catch (err) {
     console.error("❌ Intraday fetch error:", err.message);
     res.status(500).json({ error: "Failed to fetch intraday data" });
+  }
+});
+
+app.get("/support-resistance/:symbol", (req, res) => {
+  const { symbol } = req.params;
+  if (!symbol) return res.status(400).json({ error: "Missing symbol" });
+  try {
+    const levels = getSupportResistanceLevels(symbol);
+    res.json({ status: "success", ...levels });
+  } catch (err) {
+    console.error("❌ Support/resistance error:", err.message);
+    res.status(500).json({ error: "Failed to compute levels" });
+  }
+});
+
+app.get("/rebuild-3min/:token", async (req, res) => {
+  const { token } = req.params;
+  try {
+    const candles = await rebuildThreeMinCandlesFromOneMin(token);
+    res.json({ status: "success", candles });
+  } catch (err) {
+    console.error("❌ 3m rebuild error:", err.message);
+    res.status(500).json({ error: "Failed to rebuild candles" });
   }
 });
 

--- a/scanner.js
+++ b/scanner.js
@@ -12,7 +12,10 @@ import {
   calculateExpiryMinutes,
 } from "./util.js";
 
-import { getHigherTimeframeData } from "./kite.js";
+import {
+  getHigherTimeframeData,
+  getSupportResistanceLevels,
+} from "./kite.js";
 import { evaluateStrategies } from "./strategies.js";
 import { candleHistory } from "./kite.js";
 import { RISK_REWARD_RATIO, calculatePositionSize } from "./positionSizing.js";
@@ -408,6 +411,7 @@ export async function analyzeCandles(
 
     const ma20Val = getMAForSymbol(symbol, 20);
     const ma50Val = getMAForSymbol(symbol, 50);
+    const { support, resistance } = getSupportResistanceLevels(symbol);
 
     const stratResults = evaluateStrategies(validCandles, { rvol }, { topN: 5 });
     const filtered = filterStrategiesByRegime(stratResults, marketContext);
@@ -431,6 +435,9 @@ export async function analyzeCandles(
       rsi: parseFloat(rsi.toFixed(2)),
       ma20: ma20Val !== null ? parseFloat(ma20Val.toFixed(2)) : null,
       ma50: ma50Val !== null ? parseFloat(ma50Val.toFixed(2)) : null,
+      support: support !== null ? parseFloat(support.toFixed(2)) : null,
+      resistance:
+        resistance !== null ? parseFloat(resistance.toFixed(2)) : null,
       ema9: parseFloat(ema9.toFixed(2)),
       ema21: parseFloat(ema21.toFixed(2)),
       ema50: parseFloat(ema50.toFixed(2)),
@@ -467,6 +474,7 @@ export async function analyzeCandles(
         marketTrend: isUptrend ? "bullish" : isDowntrend ? "bearish" : "sideways"
       },
       context: { volatility: atrValue.toFixed(2) },
+      levels: { support, resistance },
       confidenceScore: strategyConfidence,
       executionWindow: {
         validFrom: signal.generatedAt,

--- a/tests/analyzeCandles.test.js
+++ b/tests/analyzeCandles.test.js
@@ -8,7 +8,8 @@ const kiteMock = test.mock.module('../kite.js', {
       ema50: 100,
       supertrend: { signal: 'Buy' }
     }),
-    candleHistory: {}
+    candleHistory: {},
+    getSupportResistanceLevels: () => ({ support: 90, resistance: 110 })
   }
 });
 
@@ -74,6 +75,8 @@ test('analyzeCandles returns a signal for valid data', async () => {
   assert.equal(signal.stock, 'TEST');
   assert.equal(signal.pattern, 'Breakout');
   assert.ok(signal.expiresAt);
+  assert.equal(signal.support, 90);
+  assert.equal(signal.resistance, 110);
   kiteMock.restore();
   utilMock.restore();
   dbMock.restore();

--- a/tests/rebuildThreeMinRoute.test.js
+++ b/tests/rebuildThreeMinRoute.test.js
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+
+const kiteMock = test.mock.module('../kite.js', {
+  namedExports: {
+    rebuildThreeMinCandlesFromOneMin: async () => [
+      { open: 1, high: 2, low: 0.5, close: 1.5, volume: 100 }
+    ]
+  }
+});
+
+const { rebuildThreeMinCandlesFromOneMin } = await import('../kite.js');
+
+const app = express();
+app.get('/rebuild-3min/:token', async (req, res) => {
+  const candles = await rebuildThreeMinCandlesFromOneMin(req.params.token);
+  res.json({ status: 'success', candles });
+});
+
+const server = app.listen(0);
+const port = server.address().port;
+const response = await fetch(`http://localhost:${port}/rebuild-3min/123`);
+const body = await response.json();
+server.close();
+
+kiteMock.restore();
+
+test('rebuild-3min route returns rebuilt candles', () => {
+  assert.equal(body.status, 'success');
+  assert.equal(body.candles.length, 1);
+  assert.equal(body.candles[0].open, 1);
+});

--- a/tests/supportResistanceRoute.test.js
+++ b/tests/supportResistanceRoute.test.js
@@ -1,0 +1,31 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+
+const kiteMock = test.mock.module('../kite.js', {
+  namedExports: {
+    getSupportResistanceLevels: () => ({ support: 100, resistance: 120 })
+  }
+});
+
+const { getSupportResistanceLevels } = await import('../kite.js');
+
+const app = express();
+app.get('/support-resistance/:symbol', (req, res) => {
+  const levels = getSupportResistanceLevels(req.params.symbol);
+  res.json({ status: 'success', ...levels });
+});
+
+const server = app.listen(0);
+const port = server.address().port;
+const response = await fetch(`http://localhost:${port}/support-resistance/XYZ`);
+const body = await response.json();
+server.close();
+
+kiteMock.restore();
+
+test('support-resistance route returns mocked levels', () => {
+  assert.equal(body.status, 'success');
+  assert.equal(body.support, 100);
+  assert.equal(body.resistance, 120);
+});


### PR DESCRIPTION
## Summary
- expose support/resistance utilities in scanner
- return levels in generated signals and advanced signal context
- add API routes for support/resistance and 3‑minute candle rebuild
- extend tests for new fields and add route tests

## Testing
- `node --test --experimental-test-module-mocks tests/supportResistanceRoute.test.js`
- `node --test --experimental-test-module-mocks tests/rebuildThreeMinRoute.test.js`
- `node --test --experimental-test-module-mocks tests/analyzeCandles.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6863e1531c948325b445250658cdeebd