### PR TITLE
Improve signal tracking

### DIFF
--- a/auditLogger.js
+++ b/auditLogger.js
@@ -76,7 +76,12 @@ export async function logSignalExpired(signalId, reason) {
   }
 }
 
-export async function logSignalRejected(signalId, reasonCode, validationDetails) {
+export async function logSignalRejected(
+  signalId,
+  reasonCode,
+  validationDetails,
+  signalData = null
+) {
   await secureLogStore(
     {
       type: 'signal_rejected',
@@ -87,6 +92,15 @@ export async function logSignalRejected(signalId, reasonCode, validationDetails)
     },
     ['validationDetails']
   );
+  try {
+    await db.collection('rejected_signals').insertOne({
+      signalId,
+      reasonCode,
+      validationDetails,
+      signal: signalData,
+      timestamp: new Date(),
+    });
+  } catch {}
   sendCriticalAlerts('rejection', { signalId, reasonCode });
 }
 

--- a/riskValidator.js
+++ b/riskValidator.js
@@ -92,7 +92,8 @@ export function validatePreExecution(signal, market) {
     logSignalRejected(
       signal.signalId || signal.algoSignal?.signalId,
       'rRTooLow',
-      { rr: rrInfo.rr, minRR: rrInfo.minRR }
+      { rr: rrInfo.rr, minRR: rrInfo.minRR },
+      signal
     );
     return false;
   }
@@ -109,7 +110,8 @@ export function validatePreExecution(signal, market) {
     logSignalRejected(
       signal.signalId || signal.algoSignal?.signalId,
       'slInvalid',
-      { price: market.currentPrice ?? signal.entry, stopLoss: signal.stopLoss }
+      { price: market.currentPrice ?? signal.entry, stopLoss: signal.stopLoss },
+      signal
     );
     return false;
   }
@@ -131,7 +133,8 @@ export function validatePreExecution(signal, market) {
     logSignalRejected(
       signal.signalId || signal.algoSignal?.signalId,
       'conflict',
-      { market }
+      { market },
+      signal
     );
     return false;
   }

--- a/scanner.js
+++ b/scanner.js
@@ -303,12 +303,7 @@ export async function analyzeCandles(
       return null;
     }
 
-    // Debounce logic
-    const conflictWindow = 3 * 60 * 1000;
-    if (
-      !debounceSignal(signalHistory, symbol, pattern.direction, conflictWindow)
-    )
-      return null;
+
 
     // Entry/SL/Target Calculation
     let entry =
@@ -418,6 +413,19 @@ export async function analyzeCandles(
     const [topStrategy] = filtered;
     const strategyName = topStrategy ? topStrategy.name : pattern.type;
     const strategyConfidence = topStrategy ? topStrategy.confidence : (confidence === "High" ? 0.8 : confidence === "Medium" ? 0.6 : 0.4);
+
+    // Debounce logic now that strategy name is known
+    const conflictWindow = 3 * 60 * 1000;
+    if (
+      !debounceSignal(
+        signalHistory,
+        symbol,
+        pattern.direction,
+        strategyName,
+        conflictWindow
+      )
+    )
+      return null;
 
     const signal = {
       stock: symbol,

--- a/tests/signalLifecycle.test.js
+++ b/tests/signalLifecycle.test.js
@@ -7,13 +7,20 @@ process.env.NODE_ENV = 'test';
 activeSignals.clear();
 
 const now = Date.now();
-const signal = { stock: 'TEST', direction: 'Long', expiresAt: new Date(now + 1000).toISOString(), confidence: 1 };
+const signal = {
+  stock: 'TEST',
+  direction: 'Long',
+  expiresAt: new Date(now + 1000).toISOString(),
+  confidence: 1,
+  signalId: 'sig1',
+};
 
 addSignal(signal);
 
 checkExpiries(now + 2000);
 
 test('signal expires after expiry time', () => {
-  const info = activeSignals.get('TEST');
+  const sigMap = activeSignals.get('TEST');
+  const info = sigMap.get('sig1');
   assert.equal(info.status, 'expired');
 });

--- a/util.js
+++ b/util.js
@@ -111,18 +111,19 @@ export function debounceSignal(
   signalHistory,
   symbol,
   direction,
+  strategy = 'default',
   windowMs = 180000
 ) {
   const now = Date.now();
-  const history = signalHistory[symbol] || [];
-  const conflicting = history.find(
+  const symHist = signalHistory[symbol] || {};
+  const stratHist = symHist[strategy] || [];
+  const conflicting = stratHist.find(
     (sig) => now - sig.timestamp < windowMs && sig.direction !== direction
   );
   if (conflicting) return false;
-  signalHistory[symbol] = history.filter(
-    (sig) => now - sig.timestamp < windowMs
-  );
-  signalHistory[symbol].push({ direction, timestamp: now });
+  symHist[strategy] = stratHist.filter((sig) => now - sig.timestamp < windowMs);
+  symHist[strategy].push({ direction, timestamp: now });
+  signalHistory[symbol] = symHist;
   return true;
 }
 


### PR DESCRIPTION
## Summary
- store rejected signals in a collection
- allow concurrent signals per strategy
- record strategy-based cooldowns
- update signal expiry test

## Testing
- `node --test --experimental-test-module-mocks`

------
https://chatgpt.com/codex/tasks/task_e_6863f7a695e883258dd9f70e28b2b5d9