### PR TITLE
Add trading workflow with order lifecycle

### DIFF
--- a/auditLogger.js
+++ b/auditLogger.js
@@ -159,5 +159,7 @@ async function setupIndexes() {
   }
 }
 
-setupIndexes();
-setInterval(() => archiveOldLogs().catch(() => {}), 24 * 60 * 60 * 1000);
+if (process.env.NODE_ENV !== 'test') {
+  setupIndexes();
+  setInterval(() => archiveOldLogs().catch(() => {}), 24 * 60 * 60 * 1000);
+}

--- a/tests/dynamicRiskModel.test.js
+++ b/tests/dynamicRiskModel.test.js
@@ -1,12 +1,18 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
+const riskMock = test.mock.module('../riskValidator.js', {
+  namedExports: { validateRR: () => ({ valid: true, rr: 2, minRR: 1 }) }
+});
+
 import {
   calculateDynamicStopLoss,
   calculateLotSize,
   checkExposureCap,
   adjustRiskBasedOnDrawdown,
 } from '../dynamicRiskModel.js';
+
+riskMock.restore();
 
 test('calculateDynamicStopLoss uses ATR multiplier', () => {
   const sl = calculateDynamicStopLoss({ atr: 2, entry: 100, direction: 'Long' });

--- a/tests/signalLifecycle.test.js
+++ b/tests/signalLifecycle.test.js
@@ -1,7 +1,13 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
+const auditMock = test.mock.module('../auditLogger.js', {
+  namedExports: { logSignalExpired: () => {}, logSignalMutation: () => {} }
+});
+
 import { addSignal, activeSignals, checkExpiries } from '../signalManager.js';
+
+auditMock.restore();
 process.env.NODE_ENV = 'test';
 
 activeSignals.clear();

--- a/tests/tradeLifecycle.test.js
+++ b/tests/tradeLifecycle.test.js
@@ -1,0 +1,66 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+process.env.NODE_ENV = 'test';
+
+// Prevent actual DB connections
+const dbMock = test.mock.module('../db.js', {
+  defaultExport: {
+    collection: () => ({})
+  },
+  namedExports: {
+    connectDB: async () => ({ collection: () => ({}) })
+  }
+});
+
+// Avoid audit logger side effects
+const auditMock = test.mock.module('../auditLogger.js', {
+  namedExports: {
+    logSignalRejected: () => {},
+    logSignalCreated: () => {}
+  }
+});
+
+let placed = [];
+let cancelled = [];
+let orders = [];
+
+const execMock = test.mock.module('../orderExecution.js', {
+  namedExports: {
+    placeOrder: async (variety, order) => {
+      const id = `id${placed.length + 1}`;
+      placed.push({ variety, order, id });
+      orders.push({ order_id: id, status: 'COMPLETE' });
+      return { order_id: id };
+    },
+    cancelOrder: async (variety, id) => {
+      cancelled.push({ variety, id });
+      return {};
+    },
+    getAllOrders: async () => orders,
+  },
+});
+
+const mod = await import('../tradeLifecycle.js');
+
+await mod.executeSignal(
+  {
+    stock: 'AAA',
+    direction: 'Long',
+    entry: 100,
+    stopLoss: 95,
+    target2: 110,
+  },
+  { capital: 100000 }
+);
+
+execMock.restore();
+dbMock.restore();
+auditMock.restore();
+
+test('executeSignal places entry, sl and target orders', () => {
+  assert.equal(placed.length, 3);
+});
+
+test('executeSignal cancels opposite order after fill', () => {
+  assert.equal(cancelled.length, 1);
+});

--- a/tradeLifecycle.js
+++ b/tradeLifecycle.js
@@ -1,0 +1,133 @@
+// tradeLifecycle.js
+import { placeOrder, cancelOrder, getAllOrders } from './orderExecution.js';
+import { validatePreExecution } from './riskValidator.js';
+import { calculatePositionSize } from './positionSizing.js';
+import {
+  checkExposureLimits,
+  preventReEntry,
+  resolveSignalConflicts,
+} from './portfolioContext.js';
+
+/**
+ * Wait for an order to be filled by polling getAllOrders()
+ * @param {string} orderId
+ * @param {number} [timeout=30000]
+ * @param {number} [interval=1000]
+ * @returns {Promise<boolean>} fill status
+ */
+export async function waitForOrderFill(orderId, timeout = 30000, interval = 1000) {
+  const start = Date.now();
+  while (Date.now() - start < timeout) {
+    const orders = await getAllOrders();
+    const ord = orders.find((o) => o.order_id === orderId);
+    if (ord && ord.status === 'COMPLETE') return true;
+    if (ord && ['CANCELLED', 'REJECTED'].includes(ord.status)) return false;
+    await new Promise((r) => setTimeout(r, interval));
+  }
+  return false;
+}
+
+/**
+ * Monitor SL and target orders. Cancels the opposite when one is filled.
+ * @param {string} slId
+ * @param {string} targetId
+ * @param {number} [interval=1000]
+ * @returns {Promise<'TARGET'|'SL'>}
+ */
+export async function monitorBracketOrders(slId, targetId, interval = 1000) {
+  while (true) {
+    const orders = await getAllOrders();
+    const sl = orders.find((o) => o.order_id === slId);
+    const tgt = orders.find((o) => o.order_id === targetId);
+    if (tgt && tgt.status === 'COMPLETE') {
+      if (sl) await cancelOrder('regular', slId);
+      return 'TARGET';
+    }
+    if (sl && sl.status === 'COMPLETE') {
+      if (tgt) await cancelOrder('regular', targetId);
+      return 'SL';
+    }
+    await new Promise((r) => setTimeout(r, interval));
+  }
+}
+
+/**
+ * Execute a trading signal with risk and exposure checks.
+ * Places entry order, waits for fill, then places SL and target orders.
+ * @param {Object} signal
+ * @param {Object} opts
+ * @param {number} [opts.capital]
+ * @param {number} [opts.risk]
+ * @param {number} [opts.totalCapital]
+ * @returns {Promise<Object|null>} order ids or null when blocked
+ */
+export async function executeSignal(signal, opts = {}) {
+  const symbol = signal.stock || signal.symbol;
+  if (!validatePreExecution(signal, opts.market || {})) return null;
+  const tradeValue = signal.entry * (signal.qty || 1);
+  const allowed =
+    checkExposureLimits({
+      symbol,
+      tradeValue,
+      sector: signal.sector || 'GEN',
+      totalCapital: opts.totalCapital || opts.capital || 0,
+    }) &&
+    preventReEntry(symbol) &&
+    resolveSignalConflicts({
+      symbol,
+      side: signal.direction === 'Long' ? 'long' : 'short',
+      strategy: signal.pattern,
+    });
+  if (!allowed) return null;
+  const qty =
+    signal.qty ||
+    calculatePositionSize({
+      capital: opts.capital || opts.totalCapital || 0,
+      risk: opts.risk || 0.01,
+      slPoints: Math.abs(signal.entry - signal.stopLoss),
+      price: signal.entry,
+    });
+  if (qty <= 0) return null;
+
+  const entryOrder = await placeOrder('regular', {
+    exchange: 'NSE',
+    tradingsymbol: symbol,
+    transaction_type: signal.direction === 'Long' ? 'BUY' : 'SELL',
+    quantity: qty,
+    order_type: 'LIMIT',
+    price: signal.entry,
+    product: 'MIS',
+  });
+  if (!entryOrder) return null;
+  const filled = await waitForOrderFill(entryOrder.order_id);
+  if (!filled) return null;
+
+  const exitType = signal.direction === 'Long' ? 'SELL' : 'BUY';
+  const slOrder = await placeOrder('regular', {
+    exchange: 'NSE',
+    tradingsymbol: symbol,
+    transaction_type: exitType,
+    quantity: qty,
+    order_type: 'SL',
+    price: signal.stopLoss,
+    trigger_price: signal.stopLoss,
+    product: 'MIS',
+  });
+  const targetOrder = await placeOrder('regular', {
+    exchange: 'NSE',
+    tradingsymbol: symbol,
+    transaction_type: exitType,
+    quantity: qty,
+    order_type: 'LIMIT',
+    price: signal.target2 || signal.target,
+    product: 'MIS',
+  });
+  if (!slOrder || !targetOrder) return null;
+  await monitorBracketOrders(slOrder.order_id, targetOrder.order_id);
+  return {
+    entryId: entryOrder.order_id,
+    slId: slOrder.order_id,
+    targetId: targetOrder.order_id,
+  };
+}
+


### PR DESCRIPTION
## Summary
- implement `tradeLifecycle.js` to manage order placement, SL/target and monitoring
- avoid audit logger side effects during tests
- create unit test for new trade lifecycle flow
- mock risk validator and audit logger in tests to prevent DB usage

## Testing
- `node --test --experimental-test-module-mocks tests/tradeLifecycle.test.js`
- `npm test` *(fails: ERR_TEST_FAILURE due to MongoDB connection attempts)*

------
https://chatgpt.com/codex/tasks/task_e_6864138f3f2c8325a0281afa92947170