### PR TITLE
Add breakout retest confirmation logic

### DIFF
--- a/scanner.js
+++ b/scanner.js
@@ -10,6 +10,7 @@ import {
   debounceSignal,
   detectAllPatterns,
   calculateExpiryMinutes,
+  confirmRetest,
 } from "./util.js";
 
 import {
@@ -148,6 +149,14 @@ export async function analyzeCandles(
     if (typeof pattern.stopLoss !== "number" || isNaN(pattern.stopLoss)) {
       pattern.stopLoss =
         pattern.direction === "Long" ? last.low : last.high;
+    }
+
+    if (
+      pattern.type === "Breakout" &&
+      !confirmRetest(validCandles.slice(-2), pattern.breakout, pattern.direction)
+    ) {
+      console.log(`[SKIP] ${symbol} - Breakout retest not confirmed`);
+      return null;
     }
 
     if (

--- a/strategies.js
+++ b/strategies.js
@@ -4,6 +4,7 @@ import {
   calculateSupertrend,
   calculateVWAP,
   getATR,
+  confirmRetest,
 } from "./util.js";
 
 // Default thresholds used by strategy detectors. These can be overridden
@@ -62,14 +63,8 @@ function detectEmaCrossover(candles, _ctx = {}, config = DEFAULT_CONFIG) {
 
 function detectBreakoutRetest(candles) {
   if (candles.length < 7) return null;
-  const last = candles.at(-1);
-  const prev = candles.at(-2);
-  const priorHigh = Math.max(...candles.slice(-6, -1).map((c) => c.high));
-  if (
-    last.close > priorHigh &&
-    prev.high >= priorHigh &&
-    prev.close < priorHigh
-  ) {
+  const breakout = Math.max(...candles.slice(-7, -2).map((c) => c.high));
+  if (confirmRetest(candles.slice(-2), breakout, 'Long')) {
     return { name: "Breakout + Retest", confidence: 0.7 };
   }
   return null;

--- a/tests/analyzeCandles.test.js
+++ b/tests/analyzeCandles.test.js
@@ -29,6 +29,7 @@ const utilMock = test.mock.module('../util.js', {
     getATR: () => 2.5,
     calculateExpiryMinutes: () => 10,
     debounceSignal: () => true,
+    confirmRetest: () => true,
     detectAllPatterns: () => [
       {
         type: 'Breakout',
@@ -57,7 +58,8 @@ test('analyzeCandles returns a signal for valid data', async () => {
     { open: 101, high: 103, low: 99, close: 102, volume: 110 },
     { open: 102, high: 104, low: 100, close: 103, volume: 120 },
     { open: 103, high: 105, low: 101, close: 104, volume: 130 },
-    { open: 104, high: 106, low: 102, close: 105, volume: 140 }
+    { open: 104, high: 106, low: 103.8, close: 106, volume: 150 },
+    { open: 106, high: 107, low: 105, close: 107, volume: 170 }
   ];
 
   const signal = await analyzeCandles(

--- a/tests/confirmRetest.test.js
+++ b/tests/confirmRetest.test.js
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const kiteMock = test.mock.module('../kite.js', { namedExports: { getMA: () => null } });
+const dbMock = test.mock.module('../db.js', {
+  defaultExport: {},
+  namedExports: { connectDB: async () => ({}) }
+});
+
+const { confirmRetest } = await import('../util.js');
+
+kiteMock.restore();
+dbMock.restore();
+
+test('confirmRetest validates pullback and strength', () => {
+  const candles = [
+    { open: 105, high: 105.5, low: 104.8, close: 105, volume: 100 },
+    { open: 105, high: 106.5, low: 105, close: 106.4, volume: 150 }
+  ];
+  assert.equal(confirmRetest(candles, 105, 'Long'), true);
+});

--- a/tests/dynamicRiskModel.test.js
+++ b/tests/dynamicRiskModel.test.js
@@ -5,12 +5,19 @@ const riskMock = test.mock.module('../riskValidator.js', {
   namedExports: { validateRR: () => ({ valid: true, rr: 2, minRR: 1 }) }
 });
 
-import {
+const dbMock = test.mock.module('../db.js', {
+  defaultExport: {},
+  namedExports: { connectDB: async () => ({}) }
+});
+
+const {
   calculateDynamicStopLoss,
   calculateLotSize,
   checkExposureCap,
   adjustRiskBasedOnDrawdown,
-} from '../dynamicRiskModel.js';
+} = await import('../dynamicRiskModel.js');
+
+dbMock.restore();
 
 riskMock.restore();
 

--- a/tests/riskValidator.test.js
+++ b/tests/riskValidator.test.js
@@ -1,7 +1,18 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { validateRR, getMinRRForStrategy } from '../riskValidator.js';
+const auditMock = test.mock.module('../auditLogger.js', {
+  namedExports: { logSignalRejected: () => {} }
+});
+const dbMock = test.mock.module('../db.js', {
+  defaultExport: {},
+  namedExports: { connectDB: async () => ({}) }
+});
+
+const { validateRR, getMinRRForStrategy } = await import('../riskValidator.js');
+
+auditMock.restore();
+dbMock.restore();
 
 test('validateRR respects strategy thresholds', () => {
   const res = validateRR({

--- a/tests/signalLifecycle.test.js
+++ b/tests/signalLifecycle.test.js
@@ -4,10 +4,15 @@ import assert from 'node:assert/strict';
 const auditMock = test.mock.module('../auditLogger.js', {
   namedExports: { logSignalExpired: () => {}, logSignalMutation: () => {} }
 });
+const dbMock = test.mock.module('../db.js', {
+  defaultExport: {},
+  namedExports: { connectDB: async () => ({}) }
+});
 
-import { addSignal, activeSignals, checkExpiries } from '../signalManager.js';
+const { addSignal, activeSignals, checkExpiries } = await import('../signalManager.js');
 
 auditMock.restore();
+dbMock.restore();
 process.env.NODE_ENV = 'test';
 
 activeSignals.clear();


### PR DESCRIPTION
## Summary
- enhance pattern confirmation by adding `confirmRetest`
- check retest confirmation in `analyzeCandles`
- use retest logic in strategy detection
- add unit test for retest confirmation
- update existing tests with mocks for new import

## Testing
- `node --test --experimental-test-module-mocks tests/confirmRetest.test.js`
- `node --test --experimental-test-module-mocks tests/signalLifecycle.test.js`
- `node --test --experimental-test-module-mocks tests/dynamicRiskModel.test.js` *(fails: ERR_TEST_FAILURE)*
- `node --test --experimental-test-module-mocks tests/confirmRetest.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6864206db43c83258c3a38292665fe29