### PR TITLE
Add morning preload for stock gap scan

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ import http from "http";
 import { Server } from "socket.io";
 import cors from "cors";
 import { analyzeCandles, getSignalHistory } from "./scanner.js";
+import cron from "node-cron";
 import {
   startLiveFeed,
   updateInstrumentTokens,
@@ -17,6 +18,7 @@ import {
   getSupportResistanceLevels,
   rebuildThreeMinCandlesFromOneMin,
   resetInMemoryData,
+  preloadStockData,
 } from "./kite.js";
 import { sendSignal } from "./telegram.js";
 import {
@@ -375,5 +377,21 @@ server.listen(3000, () => {
     const dummyBroker = { getPositions: async () => [] };
     trackOpenPositions(dummyBroker);
     setInterval(() => trackOpenPositions(dummyBroker), 60 * 1000);
+  }
+
+  cron.schedule(
+    "30 8 * * 1-5",
+    () => {
+      preloadStockData();
+    },
+    { timezone: "Asia/Kolkata" }
+  );
+
+  const now = new Date(
+    new Date().toLocaleString("en-US", { timeZone: "Asia/Kolkata" })
+  );
+  const minutes = now.getHours() * 60 + now.getMinutes();
+  if (minutes >= 510 && minutes <= 540) {
+    preloadStockData();
   }
 });

--- a/kite.js
+++ b/kite.js
@@ -277,6 +277,17 @@ async function warmupCandleHistory() {
   console.log("✅ Warmup candle history completed");
 }
 
+async function preloadStockData() {
+  console.log("⏳ Morning preload starting...");
+  try {
+    await warmupCandleHistory();
+    await fetchSessionData();
+    console.log("✅ Morning preload completed");
+  } catch (err) {
+    console.error("❌ Morning preload error:", err.message);
+  }
+}
+
 async function startLiveFeed(io) {
   globalIO = io;
 
@@ -1311,6 +1322,8 @@ export {
   getATR,
   getAverageVolume,
   candleHistory,
+  warmupCandleHistory,
+  preloadStockData,
   isMarketOpen,
   setStockSymbol,
   removeStockSymbol,

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "http": "^0.0.1-security",
         "kiteconnect": "^5.0.1",
         "mongodb": "^6.17.0",
+        "node-cron": "^3.0.2",
         "node-telegram-bot-api": "^0.66.0",
         "nodemon": "^3.1.10",
         "openai": "^5.1.1",
@@ -2469,6 +2470,18 @@
       },
       "engines": {
         "node": ">= 10.13"
+      }
+    },
+    "node_modules/node-cron": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.2.tgz",
+      "integrity": "sha512-iP8l0yGlNpE0e6q1o185yOApANRe47UPbLf4YxfbiNHt/RU5eBcGB/e0oudruheSf+LQeDMezqC5BVAb5wwRcQ==",
+      "license": "ISC",
+      "dependencies": {
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/node-telegram-bot-api": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "http": "^0.0.1-security",
     "kiteconnect": "^5.0.1",
     "mongodb": "^6.17.0",
+    "node-cron": "^3.0.2",
     "node-telegram-bot-api": "^0.66.0",
     "nodemon": "^3.1.10",
     "openai": "^5.1.1",


### PR DESCRIPTION
## Summary
- fetch morning session data using new `preloadStockData`
- schedule preload around 8:30 AM IST via cron
- expose warmup functions for reuse
- include node-cron in dependencies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68654f92322c83259605cf39c8cd24f8