### PR TITLE
Enable async symbol add flow

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,20 +88,9 @@ app.post("/addStockSymbol", async (req, res) => {
     return res.status(400).json({ error: "Invalid symbol" });
   }
   try {
-    const existingSymbols = await db.collection("stock_symbols").findOne({});
-    if (!existingSymbols) {
-      // ADD SYMBOLS WITH NSE PREFIX
-      await setStockSymbol(`NSE:${symbol}`);
-      await db
-        .collection("stock_symbols")
-        .insertOne({ symbols: [`NSE:${symbol}`] });
-    } else {
-      await db
-        .collection("stock_symbols")
-        .updateOne({}, { $addToSet: { symbols: `NSE:${symbol}` } });
-    }
+    await setStockSymbol(`NSE:${symbol}`);
     const updated = await db.collection("stock_symbols").findOne({});
-    res.json({ status: "success", symbols: updated.symbols }); // ⬅ send updated list
+    res.json({ status: "success", symbols: updated?.symbols || [] });
   } catch (err) {
     console.error("❌ Error:", err.message);
     res.status(500).json({ error: "Failed to update symbols" });


### PR DESCRIPTION
## Summary
- add route to always use `setStockSymbol`
- fetch data for new symbols in background and subscribe ticker

## Testing
- `timeout 30 npm test`

------
https://chatgpt.com/codex/tasks/task_e_68655c642b648325981207aec0eadb4a