### PR TITLE
Add feature engine module

### DIFF
--- a/featureEngine.js
+++ b/featureEngine.js
@@ -1,0 +1,114 @@
+// featureEngine.js
+// Provides indicator calculations and feature aggregation
+
+// Simple in-memory cache for EMA values keyed by optional id
+const emaCache = new Map();
+
+export function calculateEMA(prices, length, key) {
+  if (!prices || prices.length === 0) return null;
+  const k = 2 / (length + 1);
+  let ema;
+  let start = 0;
+  if (key && emaCache.has(key)) {
+    const cached = emaCache.get(key);
+    ema = cached.value;
+    start = cached.index + 1;
+  } else {
+    ema = prices[0];
+  }
+  for (let i = start; i < prices.length; i++) {
+    ema = prices[i] * k + ema * (1 - k);
+  }
+  if (key) emaCache.set(key, { value: ema, index: prices.length - 1 });
+  return ema;
+}
+
+export function calculateRSI(prices, length) {
+  if (!prices || prices.length < length + 1) return null;
+  let gains = 0,
+    losses = 0;
+  for (let i = prices.length - length - 1; i < prices.length - 1; i++) {
+    const diff = prices[i + 1] - prices[i];
+    if (diff >= 0) gains += diff;
+    else losses -= diff;
+  }
+  const rs = gains / (losses || 1);
+  return 100 - 100 / (1 + rs);
+}
+
+export function calculateSupertrend(candles, atrLength = 14) {
+  const lastCandle = candles[candles.length - 1];
+  return {
+    signal: lastCandle.close > lastCandle.open ? "Buy" : "Sell",
+    level: lastCandle.close,
+  };
+}
+
+export function getATR(data, period = 14) {
+  if (!data || data.length < period) return null;
+  let trSum = 0;
+  for (let i = 1; i < period; i++) {
+    const high = data[i].high,
+      low = data[i].low,
+      prevClose = data[i - 1].close;
+    const tr = Math.max(
+      high - low,
+      Math.abs(high - prevClose),
+      Math.abs(low - prevClose)
+    );
+    trSum += tr;
+  }
+  return trSum / period;
+}
+
+export function calculateVWAP(candles) {
+  if (!candles || candles.length === 0) return null;
+  const last = candles[candles.length - 1];
+  const refDate = new Date(last.timestamp || last.date);
+  refDate.setHours(0, 0, 0, 0);
+  let totalPV = 0,
+    totalVolume = 0;
+  candles.forEach((c) => {
+    const ts = new Date(c.timestamp || c.date);
+    if (ts < refDate) return;
+    const typicalPrice = (c.high + c.low + c.close) / 3;
+    totalPV += typicalPrice * (c.volume || 0);
+    totalVolume += c.volume || 0;
+  });
+  return totalVolume > 0 ? totalPV / totalVolume : null;
+}
+
+export function resetIndicatorCache() {
+  emaCache.clear();
+}
+
+export function computeFeatures(candles = []) {
+  if (!Array.isArray(candles) || candles.length === 0) return null;
+  const closes = candles.map((c) => c.close);
+
+  const ema9 = calculateEMA(closes, 9);
+  const ema21 = calculateEMA(closes, 21);
+  const ema50 = calculateEMA(closes, 50);
+  const rsi14 = calculateRSI(closes, 14);
+  const atr14 = getATR(candles, 14);
+  const supertrend = calculateSupertrend(candles, 14);
+  const vwap = calculateVWAP(candles);
+
+  const regime =
+    ema9 > ema21 && ema21 > ema50
+      ? "bullish"
+      : ema9 < ema21 && ema21 < ema50
+      ? "bearish"
+      : "neutral";
+
+  return {
+    ema9,
+    ema21,
+    ema50,
+    rsi14,
+    atr14,
+    supertrend,
+    vwap,
+    regime,
+  };
+}

--- a/kite.js
+++ b/kite.js
@@ -1,6 +1,6 @@
 // kite.js
 import { KiteConnect, KiteTicker } from "kiteconnect";
-import { calculateEMA, calculateSupertrend } from "./util.js";
+import { calculateEMA, calculateSupertrend } from "./featureEngine.js";
 import fs from "fs";
 import path from "path";
 import dotenv from "dotenv";

--- a/scanner.js
+++ b/scanner.js
@@ -4,9 +4,11 @@ import {
   calculateEMA,
   calculateRSI,
   calculateSupertrend,
+  getATR as getDailyATR,
+} from "./featureEngine.js";
+import {
   // detectPatterns,
   getMAForSymbol,
-  getATR as getDailyATR,
   debounceSignal,
   detectAllPatterns,
   calculateExpiryMinutes,

--- a/strategies.js
+++ b/strategies.js
@@ -4,8 +4,8 @@ import {
   calculateSupertrend,
   calculateVWAP,
   getATR,
-  confirmRetest,
-} from "./util.js";
+} from "./featureEngine.js";
+import { confirmRetest } from "./util.js";
 
 // Default thresholds used by strategy detectors. These can be overridden
 // via the optional `config` parameter in `evaluateStrategies`.

--- a/tests/analyzeCandles.test.js
+++ b/tests/analyzeCandles.test.js
@@ -18,7 +18,7 @@ const kiteMock = test.mock.module('../kite.js', {
   }
 });
 
-const utilMock = test.mock.module('../util.js', {
+const featureMock = test.mock.module('../featureEngine.js', {
   namedExports: {
     calculateEMA: (prices, period) => {
       if (period === 9) return 105;
@@ -30,8 +30,15 @@ const utilMock = test.mock.module('../util.js', {
     calculateRSI: () => 60,
     calculateSupertrend: () => ({ signal: 'Buy' }),
     calculateVWAP: () => 100,
-    getMAForSymbol: () => 100,
     getATR: () => 2.5,
+    resetIndicatorCache: () => {},
+    computeFeatures: () => ({})
+  }
+});
+
+const utilMock = test.mock.module('../util.js', {
+  namedExports: {
+    getMAForSymbol: () => 100,
     calculateExpiryMinutes: () => 10,
     debounceSignal: () => true,
     confirmRetest: () => true,
@@ -85,6 +92,7 @@ test('analyzeCandles returns a signal for valid data', async () => {
   assert.equal(signal.support, 90);
   assert.equal(signal.resistance, 110);
   kiteMock.restore();
+  featureMock.restore();
   utilMock.restore();
   dbMock.restore();
 });

--- a/util.js
+++ b/util.js
@@ -1,8 +1,22 @@
 // util.js
 import { getMA } from "./kite.js"; // Reuse kite.js
+import {
+  calculateEMA,
+  calculateRSI,
+  calculateSupertrend,
+  calculateVWAP,
+  getATR,
+  resetIndicatorCache,
+} from "./featureEngine.js";
 
-// Simple in-memory caches for intraday indicator calculations
-const emaCache = new Map();
+export {
+  calculateEMA,
+  calculateRSI,
+  calculateSupertrend,
+  calculateVWAP,
+  getATR,
+  resetIndicatorCache,
+};
 
 export function calculateMA(prices, length) {
   if (prices.length < length) return null;
@@ -13,86 +27,9 @@ export function calculateMA(prices, length) {
 // Calculate EMA with optional memoisation key. When a key is provided the
 // function reuses the last computed EMA value for that key to avoid
 // recalculating from the start of the array on every tick.
-export function calculateEMA(prices, length, key) {
-  if (!prices || prices.length === 0) return null;
-  const k = 2 / (length + 1);
-  let ema;
-  let start = 0;
-  if (key && emaCache.has(key)) {
-    const cached = emaCache.get(key);
-    ema = cached.value;
-    start = cached.index + 1;
-  } else {
-    ema = prices[0];
-  }
-  for (let i = start; i < prices.length; i++) {
-    ema = prices[i] * k + ema * (1 - k);
-  }
-  if (key) emaCache.set(key, { value: ema, index: prices.length - 1 });
-  return ema;
-}
-
-export function calculateRSI(prices, length) {
-  let gains = 0,
-    losses = 0;
-  for (let i = prices.length - length; i < prices.length - 1; i++) {
-    const diff = prices[i + 1] - prices[i];
-    if (diff >= 0) gains += diff;
-    else losses -= diff;
-  }
-  const rs = gains / (losses || 1);
-  return 100 - 100 / (1 + rs);
-}
-
-export function calculateSupertrend(candles, atrLength) {
-  const lastCandle = candles[candles.length - 1];
-  return {
-    signal: lastCandle.close > lastCandle.open ? "Buy" : "Sell",
-    level: lastCandle.close,
-  };
-}
 
 export function getMAForSymbol(symbol, period) {
   return getMA(symbol, period);
-}
-
-// Clear indicator caches - useful at the start of a new trading session
-export function resetIndicatorCache() {
-  emaCache.clear();
-}
-
-export function getATR(data, period = 14) {
-  if (!data || data.length < period) return null;
-  let trSum = 0;
-  for (let i = 1; i < period; i++) {
-    const high = data[i].high,
-      low = data[i].low,
-      prevClose = data[i - 1].close;
-    const tr = Math.max(
-      high - low,
-      Math.abs(high - prevClose),
-      Math.abs(low - prevClose)
-    );
-    trSum += tr;
-  }
-  return trSum / period;
-}
-
-export function calculateVWAP(candles) {
-  if (!candles || candles.length === 0) return null;
-  const last = candles[candles.length - 1];
-  const refDate = new Date(last.timestamp || last.date);
-  refDate.setHours(0, 0, 0, 0);
-  let totalPV = 0,
-    totalVolume = 0;
-  candles.forEach((c) => {
-    const ts = new Date(c.timestamp || c.date);
-    if (ts < refDate) return;
-    const typicalPrice = (c.high + c.low + c.close) / 3;
-    totalPV += typicalPrice * (c.volume || 0);
-    totalVolume += c.volume || 0;
-  });
-  return totalVolume > 0 ? totalPV / totalVolume : null;
 }
 
 export function analyzeHigherTimeframe(


### PR DESCRIPTION
## Summary
- create `featureEngine.js` with indicator calculations and market regime helper
- move indicator exports from `util.js` and adjust imports
- update strategy and scanner modules to use the new feature engine
- update tests to mock the new module
- switch kite.js to use feature engine indicators

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866bf24a8088325b8b6d2a9c5e8ec25