### PR TITLE
Implement strategyEngine dispatcher

### DIFF
--- a/scanner.js
+++ b/scanner.js
@@ -21,7 +21,8 @@ import {
   historicalCache,
 } from "./kite.js";
 import { candleHistory, symbolTokenMap } from "./dataEngine.js";
-import { evaluateStrategies, detectGapUpOrDown } from "./strategies.js";
+import { detectGapUpOrDown } from "./strategies.js";
+import { evaluateAllStrategies } from "./strategyEngine.js";
 import { RISK_REWARD_RATIO, calculatePositionSize } from "./positionSizing.js";
 import { validatePreExecution, adjustStopLoss } from "./riskValidator.js";
 import {
@@ -498,7 +499,7 @@ export async function analyzeCandles(
     const ma50Val = getMAForSymbol(symbol, 50);
     const { support, resistance } = getSupportResistanceLevels(symbol);
 
-    const stratResults = evaluateStrategies(validCandles, { rvol }, { topN: 5 });
+    const stratResults = evaluateAllStrategies({ candles: validCandles, rvol });
     const filtered = filterStrategiesByRegime(stratResults, marketContext);
     const [topStrategy] = filtered;
     const strategyName = topStrategy ? topStrategy.name : pattern.type;

--- a/strategyEngine.js
+++ b/strategyEngine.js
@@ -1,0 +1,66 @@
+import { calculateEMA, calculateRSI, calculateSupertrend } from './featureEngine.js';
+
+export function strategySupertrend({ candles }) {
+  if (!Array.isArray(candles) || candles.length < 20) return null;
+  const closes = candles.map(c => c.close);
+  const rsi = calculateRSI(closes, 14);
+  const st = calculateSupertrend(candles, 10);
+  const last = candles[candles.length - 1];
+  if (st?.signal === 'Buy' && rsi > 55) {
+    return {
+      name: 'Supertrend',
+      direction: 'Long',
+      entry: last.close,
+      stopLoss: last.low,
+      confidence: 0.6,
+    };
+  }
+  if (st?.signal === 'Sell' && rsi < 45) {
+    return {
+      name: 'Supertrend',
+      direction: 'Short',
+      entry: last.close,
+      stopLoss: last.high,
+      confidence: 0.6,
+    };
+  }
+  return null;
+}
+
+export function strategyEMAReversal({ candles }) {
+  if (!Array.isArray(candles) || candles.length < 20) return null;
+  const closes = candles.map(c => c.close);
+  const ema20 = calculateEMA(closes, 20);
+  const ema50 = calculateEMA(closes, 50);
+  const last = candles[candles.length - 1];
+  const prev = candles[candles.length - 2];
+  if (prev.close < ema20 && last.close > ema20 && ema20 > ema50) {
+    return {
+      name: 'EMA Reversal',
+      direction: 'Long',
+      entry: last.close,
+      stopLoss: prev.low,
+      confidence: 0.55,
+    };
+  }
+  if (prev.close > ema20 && last.close < ema20 && ema20 < ema50) {
+    return {
+      name: 'EMA Reversal',
+      direction: 'Short',
+      entry: last.close,
+      stopLoss: prev.high,
+      confidence: 0.55,
+    };
+  }
+  return null;
+}
+
+export function evaluateAllStrategies(context = {}) {
+  const strategies = [strategySupertrend, strategyEMAReversal];
+  const results = [];
+  for (const fn of strategies) {
+    const res = fn(context);
+    if (res) results.push(res);
+  }
+  return results;
+}


### PR DESCRIPTION
## Summary
- create `strategyEngine.js` with modular strategy functions
- dispatch multiple strategy checks via `evaluateAllStrategies`
- integrate new dispatcher into `scanner.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866c59304d08325a30a983e73d186ea