### PR TITLE
Fix computeGapPercent crash when historical data missing

### DIFF
--- a/kite.js
+++ b/kite.js
@@ -1005,10 +1005,12 @@ async function fetchHistoricalData(symbols = stockSymbols) {
 }
 async function loadHistoricalCache() {
   try {
-    historicalCache = await db.collection("historical_data").findOne({});
+    const data = await db.collection("historical_data").findOne({});
+    historicalCache = data || {};
     console.log("✅ historical_data.json loaded into cache");
   } catch (err) {
     console.warn("⚠️ Could not load historical data:", err.message);
+    historicalCache = {};
   }
 }
 fetchHistoricalData().then(() => loadHistoricalCache());


### PR DESCRIPTION
## Summary
- avoid null assignment when loading historical data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68674f75cb1883259017d80d7102a1cd