### PR TITLE
Implement advanced signal ranking

### DIFF
--- a/signalRanker.js
+++ b/signalRanker.js
@@ -1,15 +1,55 @@
-export function rankSignals(signals = []) {
+import { getStrategyHitRate, timeOfDayScore } from './confidence.js';
+
+function confidenceLevelScore(level) {
+  if (typeof level === 'number') return Math.max(0, Math.min(level, 1));
+  const map = { high: 1, medium: 0.7, low: 0.4 };
+  return map[(level || '').toLowerCase()] ?? 0.5;
+}
+
+function patternStrengthScore(strength) {
+  if (typeof strength === 'number') return Math.max(0, Math.min(strength, 1));
+  const map = { strong: 1, medium: 0.6, weak: 0.3 };
+  return map[(strength || '').toLowerCase()] ?? 0.5;
+}
+
+function rrPotentialScore(signal) {
+  const { entry, stopLoss, target2, target1 } = signal;
+  if (!entry || !stopLoss) return 0;
+  const target = target2 ?? target1;
+  if (!target) return 0;
+  const risk = Math.abs(entry - stopLoss);
+  const reward = Math.abs(target - entry);
+  if (!risk) return 0;
+  return Math.min(reward / risk / 3, 1); // saturate at RR=3
+}
+
+function scoreSignal(signal = {}) {
+  const confScore = confidenceLevelScore(signal.confidence);
+  const todScore = timeOfDayScore(signal.time ? new Date(signal.time) : new Date());
+  const hitRate =
+    typeof signal.winRate === 'number'
+      ? signal.winRate
+      : getStrategyHitRate(signal.stock || '', signal.pattern || '');
+  const rrScore = rrPotentialScore(signal);
+  const patternScore = patternStrengthScore(signal.patternStrength);
+
+  return (
+    confScore * 0.3 +
+    todScore * 0.1 +
+    hitRate * 0.25 +
+    rrScore * 0.2 +
+    patternScore * 0.15
+  );
+}
+
+export function rankSignals(signals = [], topN = 1) {
   if (!Array.isArray(signals) || signals.length === 0) return [];
-  return [...signals].sort((a, b) => {
-    const ca = a.confidenceScore || a.confidence || 0;
-    const cb = b.confidenceScore || b.confidence || 0;
-    const ba = a.backtestScore || 0;
-    const bb = b.backtestScore || 0;
-    return cb + bb - (ca + ba);
-  });
+  const ranked = signals
+    .map((s) => ({ ...s, score: scoreSignal(s) }))
+    .sort((a, b) => b.score - a.score);
+  return ranked.slice(0, topN);
 }
 
 export function selectTopSignal(signals = []) {
-  const ranked = rankSignals(signals);
-  return ranked[0] || null;
+  return rankSignals(signals, 1)[0] || null;
 }

--- a/tests/signalRanker.test.js
+++ b/tests/signalRanker.test.js
@@ -1,0 +1,57 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { rankSignals } from '../signalRanker.js';
+import { recordStrategyResult } from '../confidence.js';
+
+const baseTime = new Date('2023-01-01T10:00:00Z');
+
+// Build some strategy stats
+recordStrategyResult('AAA', 'trend', true);
+recordStrategyResult('BBB', 'trend', false);
+recordStrategyResult('CCC', 'trend', true);
+
+const signals = [
+  {
+    stock: 'AAA',
+    pattern: 'trend',
+    confidence: 'High',
+    entry: 100,
+    stopLoss: 99,
+    target1: 104,
+    patternStrength: 'strong',
+    time: baseTime.toISOString(),
+  },
+  {
+    stock: 'BBB',
+    pattern: 'trend',
+    confidence: 'Medium',
+    entry: 100,
+    stopLoss: 99,
+    target1: 101,
+    patternStrength: 'weak',
+    time: baseTime.toISOString(),
+  },
+  {
+    stock: 'CCC',
+    pattern: 'trend',
+    confidence: 'Low',
+    entry: 100,
+    stopLoss: 99,
+    target1: 103,
+    patternStrength: 'medium',
+    time: baseTime.toISOString(),
+  },
+];
+
+test('rankSignals returns top signal based on score', () => {
+  const [top] = rankSignals(signals);
+  assert.equal(top.stock, 'AAA');
+});
+
+test('rankSignals can return top N signals', () => {
+  const topTwo = rankSignals(signals, 2);
+  assert.equal(topTwo.length, 2);
+  assert.equal(topTwo[0].stock, 'AAA');
+  assert.ok(topTwo[0].score >= topTwo[1].score);
+});


### PR DESCRIPTION
## Summary
- enhance ranking logic in `signalRanker.js`
- rank signals by confidence, time of day, strategy hit rate, risk/reward and pattern strength
- add tests for the new ranking behaviour

## Testing
- `node --test --experimental-test-module-mocks tests/signalRanker.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6868012af3d483258477b3df8857cd88