### PR TITLE
Implement advanced order execution utilities

### DIFF
--- a/tests/tradeLifecycle.test.js
+++ b/tests/tradeLifecycle.test.js
@@ -26,7 +26,7 @@ let orders = [];
 
 const execMock = test.mock.module('../orderExecution.js', {
   namedExports: {
-    placeOrder: async (variety, order) => {
+    sendOrder: async (variety, order) => {
       const id = `id${placed.length + 1}`;
       placed.push({ variety, order, id });
       orders.push({ order_id: id, status: 'COMPLETE' });

--- a/tradeLifecycle.js
+++ b/tradeLifecycle.js
@@ -1,5 +1,5 @@
 // tradeLifecycle.js
-import { placeOrder, cancelOrder, getAllOrders } from './orderExecution.js';
+import { sendOrder, cancelOrder, getAllOrders } from './orderExecution.js';
 import { isSignalValid } from './riskEngine.js';
 import { calculatePositionSize } from './positionSizing.js';
 import {
@@ -89,7 +89,7 @@ export async function executeSignal(signal, opts = {}) {
     });
   if (qty <= 0) return null;
 
-  const entryOrder = await placeOrder('regular', {
+  const entryOrder = await sendOrder('regular', {
     exchange: 'NSE',
     tradingsymbol: symbol,
     transaction_type: signal.direction === 'Long' ? 'BUY' : 'SELL',
@@ -103,7 +103,7 @@ export async function executeSignal(signal, opts = {}) {
   if (!filled) return null;
 
   const exitType = signal.direction === 'Long' ? 'SELL' : 'BUY';
-  const slOrder = await placeOrder('regular', {
+  const slOrder = await sendOrder('regular', {
     exchange: 'NSE',
     tradingsymbol: symbol,
     transaction_type: exitType,
@@ -113,7 +113,7 @@ export async function executeSignal(signal, opts = {}) {
     trigger_price: signal.stopLoss,
     product: 'MIS',
   });
-  const targetOrder = await placeOrder('regular', {
+  const targetOrder = await sendOrder('regular', {
     exchange: 'NSE',
     tradingsymbol: symbol,
     transaction_type: exitType,


### PR DESCRIPTION
## Summary
- expose `sendOrder` for raw order submission
- add `monitorOrder`, `cancelStaleOrders` and enhanced `placeOrder` with retry logic
- update trade lifecycle module and tests for new helper name

## Testing
- `npm test` *(fails: ERR_TEST_FAILURE)*

------
https://chatgpt.com/codex/tasks/task_e_6868070751288325a12891925fab1031