### PR TITLE
Add feedback learning module

### DIFF
--- a/feedbackEngine.js
+++ b/feedbackEngine.js
@@ -1,16 +1,84 @@
+import db from './db.js';
+
+// Track strategy weights and historical performance
 const weights = new Map();
+const stats = new Map(); // { strategy: { wins, trades } }
 
 export function updateStrategyWeight(name, delta) {
-  const w = weights.get(name) || 1;
-  weights.set(name, Math.max(0.1, w + delta));
+  const w = weights.get(name) ?? 1;
+  const nw = Math.max(0.1, Math.min(w + delta, 2));
+  weights.set(name, nw);
 }
 
 export function getStrategyWeight(name) {
-  return weights.get(name) || 1;
+  return weights.get(name) ?? 1;
 }
 
 export function adjustWeights(results = []) {
   for (const r of results) {
     updateStrategyWeight(r.strategy, r.outcome > 0 ? 0.1 : -0.1);
   }
+}
+
+/**
+ * Record the outcome of a signal/trade for learning purposes.
+ * @param {Object} signal - Signal info with `pattern` or `strategy` name
+ * @param {number} result - Positive for win, negative for loss
+ */
+export async function recordSignalOutcome(signal = {}, result = 0) {
+  const strategy = signal.pattern || signal.strategy || signal.name;
+  if (!strategy) return;
+
+  // Persist outcome when db connection available
+  try {
+    if (db?.collection) {
+      await db.collection('signal_results').insertOne({
+        strategy,
+        symbol: signal.stock || signal.symbol,
+        result,
+        timestamp: new Date(),
+      });
+    }
+  } catch (_) {
+    /* ignore db errors in lightweight environments */
+  }
+
+  const stat = stats.get(strategy) || { wins: 0, trades: 0 };
+  stat.trades += 1;
+  if (result > 0) stat.wins += 1;
+  stats.set(strategy, stat);
+
+  updateStrategyWeight(strategy, result > 0 ? 0.1 : -0.1);
+}
+
+/**
+ * Adjust signal confidence based on historical win rate.
+ */
+export function adjustConfidence(signal = {}) {
+  const strategy = signal.pattern || signal.strategy || signal.name;
+  if (!strategy) return signal;
+  const stat = stats.get(strategy);
+  if (!stat || stat.trades === 0) return signal;
+  const winRate = stat.wins / stat.trades;
+  const factor = 1 + (winRate - 0.5); // ranges roughly 0.5 - 1.5
+  if (typeof signal.confidence === 'number') {
+    signal.confidence = Math.max(0, Math.min(signal.confidence * factor, 1));
+  }
+  return signal;
+}
+
+/**
+ * Determine if a strategy should be temporarily throttled
+ * based on poor win rate.
+ */
+export function shouldThrottle(name, minTrades = 5) {
+  const stat = stats.get(name);
+  if (!stat || stat.trades < minTrades) return false;
+  const winRate = stat.wins / stat.trades;
+  return winRate < 0.4;
+}
+
+// Exported for tests
+export function _getStats() {
+  return stats;
 }

--- a/tests/feedbackEngine.test.js
+++ b/tests/feedbackEngine.test.js
@@ -1,0 +1,56 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+process.env.NODE_ENV = 'test';
+
+let inserted = [];
+
+const dbMock = test.mock.module('../db.js', {
+  defaultExport: {
+    collection: () => ({
+      insertOne: async (doc) => {
+        inserted.push(doc);
+      }
+    })
+  },
+  namedExports: { connectDB: async () => ({}) }
+});
+
+const {
+  recordSignalOutcome,
+  shouldThrottle,
+  adjustConfidence,
+  _getStats
+} = await import('../feedbackEngine.js');
+
+dbMock.restore();
+
+_testCleanup();
+function _testCleanup(){
+  inserted = [];
+  _getStats().clear && _getStats().clear();
+}
+
+// Use a hook for each test to reset state
+
+test('recordSignalOutcome stores result and updates stats', async () => {
+  _testCleanup();
+  await recordSignalOutcome({ pattern: 'strat', stock: 'AAA' }, 1);
+  const stat = _getStats().get('strat');
+  assert.equal(stat.wins, 1);
+  assert.equal(stat.trades, 1);
+  assert.equal(inserted.length, 1);
+});
+
+test('shouldThrottle flags low win rate strategies', () => {
+  _testCleanup();
+  _getStats().set('low', { wins: 1, trades: 5 });
+  assert.equal(shouldThrottle('low'), true);
+});
+
+test('adjustConfidence scales confidence with win rate', () => {
+  _testCleanup();
+  _getStats().set('hi', { wins: 4, trades: 5 });
+  const sig = { pattern: 'hi', confidence: 0.5 };
+  adjustConfidence(sig);
+  assert.ok(sig.confidence > 0.5);
+});


### PR DESCRIPTION
## Summary
- implement dynamic feedback engine
- record outcomes and throttle weak strategies
- add unit tests for feedback engine

## Testing
- `node --test --experimental-test-module-mocks tests/feedbackEngine.test.js`
- `node --test --experimental-test-module-mocks` *(fails: write EPIPE)*

------
https://chatgpt.com/codex/tasks/task_e_68681078d00083258f87854a5e98d2a1