### PR TITLE
Implement periodic exit checks

### DIFF
--- a/scanner.js
+++ b/scanner.js
@@ -26,6 +26,9 @@ import { evaluateAllStrategies } from "./strategyEngine.js";
 import { RISK_REWARD_RATIO, calculatePositionSize } from "./positionSizing.js";
 import { adjustStopLoss } from "./riskValidator.js";
 import { isSignalValid } from "./riskEngine.js";
+import { startExitMonitor } from "./exitManager.js";
+import { openPositions, recordExit } from "./portfolioContext.js";
+import { logTrade } from "./tradeLogger.js";
 import {
   calculateDynamicStopLoss,
   adjustRiskBasedOnDrawdown,
@@ -617,4 +620,16 @@ export async function analyzeCandles(
 
 export function getSignalHistory() {
   return signalHistory;
+}
+
+function handleExit(trade, reason) {
+  recordExit(trade.symbol);
+  logTrade({ symbol: trade.symbol, reason, event: 'exit' });
+}
+
+if (process.env.NODE_ENV !== 'test') {
+  startExitMonitor(openPositions, {
+    exitTrade: handleExit,
+    logTradeExit: handleExit,
+  });
 }

--- a/tests/exitManager.test.js
+++ b/tests/exitManager.test.js
@@ -2,7 +2,13 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 const mod = await import('../exitManager.js');
-const { setTrailingPercent, applyTrailingSL, forceTimeExit, detectReversalExit, checkExitConditions } = mod;
+const {
+  setTrailingPercent,
+  applyTrailingSL,
+  forceTimeExit,
+  detectReversalExit,
+  checkExitConditions,
+} = mod;
 
 setTrailingPercent(10); // easier to test
 
@@ -28,5 +34,6 @@ test('detectReversalExit finds simple reversal', () => {
 
 test('checkExitConditions returns first matching reason', () => {
   const pos = { side: 'Long', entryPrice: 100, stopLoss: 90, lastPrice: 80 };
-  assert.equal(checkExitConditions(pos), 'trailing');
+  const res = checkExitConditions(pos);
+  assert.deepEqual(res, { shouldExit: true, reason: 'TrailingStop' });
 });


### PR DESCRIPTION
## Summary
- implement ATR-based trailing stop and time/reversal exits
- expose startExitMonitor loop
- invoke exit monitoring from `scanner.js`
- update exit manager tests

## Testing
- `node --test tests/exitManager.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68681d4c438083259472bf16d5d3ec24