### PR TITLE
Centralize risk filtering

### DIFF
--- a/riskEngine.js
+++ b/riskEngine.js
@@ -35,6 +35,8 @@ export function isSignalValid(signal, ctx = {}) {
   const maxTrades = ctx.maxTradesPerDay ?? riskState.maxTradesPerDay;
   if (riskState.tradeCount >= maxTrades) return false;
 
+  if (signal.expiresAt && now > new Date(signal.expiresAt).getTime()) return false;
+
   const rr = validateRR({
     strategy: signal.algoSignal?.strategy || signal.pattern,
     entry: signal.entry,
@@ -43,6 +45,7 @@ export function isSignalValid(signal, ctx = {}) {
     winrate: ctx.winrate || 0,
   });
   if (!rr.valid) return false;
+  if (typeof ctx.minRR === 'number' && rr.rr < ctx.minRR) return false;
 
   if (typeof ctx.minATR === 'number' && signal.atr < ctx.minATR) return false;
   if (typeof ctx.maxATR === 'number' && signal.atr > ctx.maxATR) return false;

--- a/scanner.js
+++ b/scanner.js
@@ -190,13 +190,6 @@ export async function analyzeCandles(
       return null;
     }
 
-    if (atrValue < filters.atrThreshold) return null;
-    if (atrValue > filters.maxATR) {
-      console.log(
-        `[SKIP] ${symbol} - ATR ${atrValue.toFixed(2)} exceeds limit`
-      );
-      return null;
-    }
 
     const possiblePatterns = detectAllPatterns(validCandles, atrValue);
     if (!possiblePatterns || possiblePatterns.length === 0) return null;
@@ -480,13 +473,6 @@ export async function analyzeCandles(
       (pattern.direction === "Long" ? 1 : -1) * (rrMultiplier * 0.5) * baseRisk;
     let target2 =
       entry + (pattern.direction === "Long" ? 1 : -1) * rrMultiplier * baseRisk;
-
-    const rr = Math.abs((target2 - entry) / baseRisk);
-    if (rr < RISK_REWARD_RATIO) {
-      console.log(`[SKIP] ${symbol} - R:R below 1:${RISK_REWARD_RATIO}. RR = ${rr.toFixed(2)}`);
-      return null;
-    }
-
     // Adjustments from live tick data
     if (liveTick) {
       const buyPressure = liveTick.total_buy_quantity || 0;
@@ -612,6 +598,7 @@ export async function analyzeCandles(
       marketRegime: marketContext.regime,
       minATR: FILTERS.atrThreshold,
       maxATR: FILTERS.maxATR,
+      minRR: RISK_REWARD_RATIO,
     });
     if (!ok) return null;
 


### PR DESCRIPTION
## Summary
- check signal expiry and min RR inside `isSignalValid`
- remove ATR and RR filtering from `scanner.js`
- pass `minRR` to `isSignalValid`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6869e8366fc883258d3b6376c30bf334