### PR TITLE
Add order execution helper

### DIFF
--- a/scanner.js
+++ b/scanner.js
@@ -37,6 +37,7 @@ import {
   getStrategyHitRate,
   signalQualityScore,
 } from "./confidence.js";
+import { sendToExecution } from "./orderExecution.js";
 
 // 📊 Signal history tracking
 const signalHistory = {};
@@ -627,3 +628,14 @@ if (process.env.NODE_ENV !== 'test') {
     logTradeExit: handleExit,
   });
 }
+
+// Rank signals and send top one to execution
+export async function rankAndExecute(signals = []) {
+  const { selectTopSignal } = await import("./signalRanker.js");
+  const top = selectTopSignal(signals);
+  if (top) {
+    await sendToExecution(top);
+  }
+  return top;
+}
+


### PR DESCRIPTION
## Summary
- add `sendToExecution` for placing entry, SL and target orders
- expose helper to rank and execute signals
- fix missing logger import in order execution module

## Testing
- `npm test --silent` *(fails: analyzeCandles returns a signal for valid data)*

------
https://chatgpt.com/codex/tasks/task_e_686a0f3e66a083258a691ce52edf7e99