### PR TITLE
Refactor confidence evaluation

### DIFF
--- a/confidence.js
+++ b/confidence.js
@@ -1,4 +1,5 @@
 // confidence.js
+import { getHigherTimeframeData } from './kite.js';
 
 // In-memory strategy statistics { symbol: { strategy: { wins, trades } } }
 export const strategyStats = {};
@@ -46,4 +47,139 @@ export function computeConfidenceScore({
     confirmationScore(confirmations) * 0.2 +
     quality * 0.2;
   return Math.max(0, Math.min(score, 1));
+}
+
+export async function evaluateTrendConfidence(context = {}, pattern = {}) {
+  const {
+    features = {},
+    tick,
+    liquidity,
+    spread = 0,
+    depth,
+    totalBuy = 0,
+    totalSell = 0,
+    last,
+    filters = {},
+    symbol,
+    quality = 0.5,
+    history = {},
+  } = context;
+
+  const {
+    ema9 = 0,
+    ema21 = 0,
+    ema50 = 0,
+    supertrend = {},
+  } = features;
+
+  const { minBuySellRatio = 0.8, maxSpread = Infinity, minLiquidity = 0 } =
+    filters;
+
+  const isUptrend = ema9 > ema21 && ema21 > ema50;
+  const isDowntrend = ema9 < ema21 && ema21 < ema50;
+  const isTrendClean =
+    (pattern.direction === 'Long' && isUptrend) ||
+    (pattern.direction === 'Short' && isDowntrend);
+
+  let confidence = isTrendClean ? 'High' : 'Medium';
+
+  if (tick?.volume_traded && liquidity && liquidity !== 'NA') {
+    const ratio = tick.volume_traded / liquidity;
+    if (ratio > 2.5) {
+      if (
+        pattern.direction === 'Long' &&
+        tick.total_buy_quantity > tick.total_sell_quantity * 1.5
+      ) {
+        confidence = 'High';
+      } else if (
+        pattern.direction === 'Short' &&
+        tick.total_sell_quantity > tick.total_buy_quantity * 1.5
+      ) {
+        confidence = 'High';
+      }
+    }
+    if (ratio < 0.3) {
+      return { confidence: 'Low', score: 0 };
+    }
+  }
+
+  if (
+    (pattern.direction === 'Long' && ema9 < ema21 * 0.98) ||
+    (pattern.direction === 'Short' && ema9 > ema21 * 1.02)
+  ) {
+    confidence = 'Medium';
+  }
+
+  if (
+    (pattern.direction === 'Long' && supertrend.signal === 'Sell') ||
+    (pattern.direction === 'Short' && supertrend.signal === 'Buy')
+  ) {
+    confidence = 'Low';
+  }
+
+  if (
+    (pattern.direction === 'Long' && totalBuy < totalSell * 0.9) ||
+    (pattern.direction === 'Short' && totalSell < totalBuy * 0.9)
+  ) {
+    confidence = 'Low';
+  }
+
+  const higherTF = await getHigherTimeframeData(symbol, '15minute');
+  if (!higherTF) return { confidence: 'Low', score: 0 };
+
+  const { ema50: higherEMA50 = 0, supertrend: higherSuper = {} } = higherTF;
+  const higherTrendOk =
+    (pattern.direction === 'Long' &&
+      higherSuper.signal === 'Buy' &&
+      last?.close > higherEMA50 * 0.98) ||
+    (pattern.direction === 'Short' &&
+      higherSuper.signal === 'Sell' &&
+      last?.close < higherEMA50 * 1.02);
+
+  if (!higherTrendOk && confidence !== 'Low') confidence = 'Medium';
+
+  if (depth) {
+    const bestBid = depth.buy?.[0]?.price || 0;
+    const bestAsk = depth.sell?.[0]?.price || 0;
+    const ratio = totalBuy / (totalSell || 1);
+    if (
+      (pattern.direction === 'Long' && bestBid < last.close * 0.995) ||
+      (pattern.direction === 'Short' && bestAsk > last.close * 1.005)
+    ) {
+      confidence = 'Low';
+    }
+    if (
+      (pattern.direction === 'Long' && ratio < minBuySellRatio) ||
+      (pattern.direction === 'Short' && ratio > 1 / minBuySellRatio)
+    ) {
+      confidence = 'Low';
+    }
+  }
+
+  if (spread > maxSpread || liquidity < Math.max(minLiquidity, liquidity * 0.6)) {
+    confidence = 'Low';
+  }
+
+  if (confidence === 'Low') return { confidence: 'Low', score: 0 };
+
+  let confirmations = 0;
+  const hist = history[symbol] || {};
+  for (const arr of Object.values(hist)) {
+    confirmations += arr.filter(
+      (s) => Date.now() - s.timestamp < 5 * 60 * 1000 && s.direction === pattern.direction
+    ).length;
+  }
+  const baseScore = confidence === 'High' ? 0.8 : confidence === 'Medium' ? 0.6 : 0.4;
+  const hitRate = getStrategyHitRate(symbol, pattern.type);
+  const dynamicScore = computeConfidenceScore({
+    hitRate,
+    confirmations,
+    quality,
+    date: new Date(),
+  });
+  const finalScore = (baseScore + dynamicScore) / 2;
+  const finalConfidence =
+    finalScore >= 0.75 ? 'High' : finalScore >= 0.5 ? 'Medium' : 'Low';
+
+  return { confidence: finalConfidence, score: finalScore };
 }

--- a/tests/confidence.test.js
+++ b/tests/confidence.test.js
@@ -22,3 +22,78 @@ test('computeConfidenceScore low factors', () => {
   });
   assert.ok(score < 0.5);
 });
+
+test('evaluateTrendConfidence basic high', async () => {
+  const kiteMock = test.mock.module('../kite.js', {
+    namedExports: {
+      getHigherTimeframeData: async () => ({
+        ema50: 90,
+        supertrend: { signal: 'Buy' }
+      })
+    }
+  });
+  const { evaluateTrendConfidence } = await import('../confidence.js');
+  const res = await evaluateTrendConfidence(
+    {
+      features: {
+        ema9: 105,
+        ema21: 100,
+        ema50: 95,
+        supertrend: { signal: 'Buy' }
+      },
+      tick: {
+        volume_traded: 600,
+        total_buy_quantity: 900,
+        total_sell_quantity: 200
+      },
+      liquidity: 200,
+      spread: 0.5,
+      depth: { buy: [{ price: 101 }], sell: [{ price: 101.2 }] },
+      totalBuy: 1000,
+      totalSell: 800,
+      last: { close: 102 },
+      filters: { minBuySellRatio: 0.8, maxSpread: 1.5, minLiquidity: 100 },
+      symbol: 'AAA',
+      quality: 1,
+      history: {}
+    },
+    { direction: 'Long', type: 'Breakout' }
+  );
+  assert.equal(res.confidence, 'High');
+  kiteMock.restore();
+});
+
+test('evaluateTrendConfidence low on weak volume', async () => {
+  const kiteMock = test.mock.module('../kite.js', {
+    namedExports: {
+      getHigherTimeframeData: async () => ({
+        ema50: 90,
+        supertrend: { signal: 'Buy' }
+      })
+    }
+  });
+  const { evaluateTrendConfidence } = await import('../confidence.js');
+  const res = await evaluateTrendConfidence(
+    {
+      features: {
+        ema9: 105,
+        ema21: 100,
+        ema50: 95,
+        supertrend: { signal: 'Buy' }
+      },
+      tick: { volume_traded: 10, total_buy_quantity: 6, total_sell_quantity: 4 },
+      liquidity: 1000,
+      spread: 0.5,
+      totalBuy: 500,
+      totalSell: 400,
+      last: { close: 101 },
+      filters: { minBuySellRatio: 0.8, maxSpread: 1.5, minLiquidity: 100 },
+      symbol: 'AAA',
+      quality: 0.7,
+      history: {}
+    },
+    { direction: 'Long', type: 'Breakout' }
+  );
+  assert.equal(res.confidence, 'Low');
+  kiteMock.restore();
+});


### PR DESCRIPTION
## Summary
- centralize trend and volume evaluation into `confidence.js`
- compute trend info in `scanner.js` and call `evaluateTrendConfidence`
- extend confidence unit tests for new helper

## Testing
- `npm test` *(fails: Mongo connection attempt)*

------
https://chatgpt.com/codex/tasks/task_e_686b47fb6a508325b58cb772cc87d8d2