### PR TITLE
Refactor pattern detection into strategy layer

### DIFF
--- a/strategyEngine.js
+++ b/strategyEngine.js
@@ -7,26 +7,50 @@ import {
   computeFeatures,
 } from './featureEngine.js';
 import { detectAllPatterns } from './util.js';
+import { RISK_REWARD_RATIO, calculatePositionSize } from './positionSizing.js';
 
 export function strategySupertrend(context = {}) {
-  const { candles = [], features = computeFeatures(candles) } = context;
+  const {
+    candles = [],
+    features = computeFeatures(candles),
+    symbol,
+    accountBalance = 0,
+    riskPerTradePercentage = 0.01,
+    spread = 0,
+    liquidity = 0,
+  } = context;
   if (!Array.isArray(candles) || candles.length < 20) return null;
 
-  const { rsi, supertrend } = features || {};
+  const { rsi, supertrend, atr = getATR(candles, 14) } = features || {};
   const last = candles[candles.length - 1];
 
   if (supertrend?.signal === 'Buy' && rsi > 55) {
     const entry = last.close;
     const stopLoss = last.low;
     const risk = entry - stopLoss;
+    const qty = calculatePositionSize({
+      capital: accountBalance,
+      risk: accountBalance * riskPerTradePercentage,
+      slPoints: risk,
+      price: entry,
+      volatility: atr,
+    });
     return {
+      stock: symbol,
+      strategy: 'Supertrend',
+      pattern: 'Supertrend',
+      direction: 'Long',
       entry,
       stopLoss,
       target1: entry + risk * 0.75,
       target2: entry + risk * 1.5,
-      direction: 'Long',
-      strategy: 'Supertrend',
+      qty,
+      atr,
+      spread,
+      liquidity,
       confidence: 0.6,
+      generatedAt: new Date().toISOString(),
+      source: 'strategySupertrend',
     };
   }
 
@@ -34,14 +58,29 @@ export function strategySupertrend(context = {}) {
     const entry = last.close;
     const stopLoss = last.high;
     const risk = stopLoss - entry;
+    const qty = calculatePositionSize({
+      capital: accountBalance,
+      risk: accountBalance * riskPerTradePercentage,
+      slPoints: risk,
+      price: entry,
+      volatility: atr,
+    });
     return {
+      stock: symbol,
+      strategy: 'Supertrend',
+      pattern: 'Supertrend',
+      direction: 'Short',
       entry,
       stopLoss,
       target1: entry - risk * 0.75,
       target2: entry - risk * 1.5,
-      direction: 'Short',
-      strategy: 'Supertrend',
+      qty,
+      atr,
+      spread,
+      liquidity,
       confidence: 0.6,
+      generatedAt: new Date().toISOString(),
+      source: 'strategySupertrend',
     };
   }
 
@@ -49,7 +88,15 @@ export function strategySupertrend(context = {}) {
 }
 
 export function strategyEMAReversal(context = {}) {
-  const { candles = [], features = computeFeatures(candles) } = context;
+  const {
+    candles = [],
+    features = computeFeatures(candles),
+    symbol,
+    accountBalance = 0,
+    riskPerTradePercentage = 0.01,
+    spread = 0,
+    liquidity = 0,
+  } = context;
   if (!Array.isArray(candles) || candles.length < 20) return null;
 
   const closes = candles.map(c => c.close);
@@ -62,14 +109,29 @@ export function strategyEMAReversal(context = {}) {
     const entry = last.close;
     const stopLoss = prev.low;
     const risk = entry - stopLoss;
+    const qty = calculatePositionSize({
+      capital: accountBalance,
+      risk: accountBalance * riskPerTradePercentage,
+      slPoints: risk,
+      price: entry,
+      volatility: risk,
+    });
     return {
+      stock: symbol,
+      strategy: 'EMA Reversal',
+      pattern: 'EMA Reversal',
+      direction: 'Long',
       entry,
       stopLoss,
       target1: entry + risk * 0.5,
       target2: entry + risk * 1,
-      direction: 'Long',
-      strategy: 'EMA Reversal',
+      qty,
+      atr: risk,
+      spread,
+      liquidity,
       confidence: 0.55,
+      generatedAt: new Date().toISOString(),
+      source: 'strategyEMAReversal',
     };
   }
 
@@ -77,14 +139,29 @@ export function strategyEMAReversal(context = {}) {
     const entry = last.close;
     const stopLoss = prev.high;
     const risk = stopLoss - entry;
+    const qty = calculatePositionSize({
+      capital: accountBalance,
+      risk: accountBalance * riskPerTradePercentage,
+      slPoints: risk,
+      price: entry,
+      volatility: risk,
+    });
     return {
+      stock: symbol,
+      strategy: 'EMA Reversal',
+      pattern: 'EMA Reversal',
+      direction: 'Short',
       entry,
       stopLoss,
       target1: entry - risk * 0.5,
       target2: entry - risk * 1,
-      direction: 'Short',
-      strategy: 'EMA Reversal',
+      qty,
+      atr: risk,
+      spread,
+      liquidity,
       confidence: 0.55,
+      generatedAt: new Date().toISOString(),
+      source: 'strategyEMAReversal',
     };
   }
 
@@ -92,7 +169,15 @@ export function strategyEMAReversal(context = {}) {
 }
 
 export function strategyTripleTop(context = {}) {
-  const { candles = [], features = computeFeatures(candles) } = context;
+  const {
+    candles = [],
+    features = computeFeatures(candles),
+    symbol,
+    accountBalance = 0,
+    riskPerTradePercentage = 0.01,
+    spread = 0,
+    liquidity = 0,
+  } = context;
   if (!Array.isArray(candles) || candles.length < 7) return null;
 
   const atr = features?.atr ?? getATR(candles, 14);
@@ -105,19 +190,42 @@ export function strategyTripleTop(context = {}) {
   const entry = tripleTop.breakout;
   const stopLoss = tripleTop.stopLoss;
   const risk = stopLoss - entry;
+  const qty = calculatePositionSize({
+    capital: accountBalance,
+    risk: accountBalance * riskPerTradePercentage,
+    slPoints: risk,
+    price: entry,
+    volatility: atr,
+  });
   return {
+    stock: symbol,
+    strategy: 'Triple Top',
+    pattern: 'Triple Top',
+    direction: 'Short',
     entry,
     stopLoss,
     target1: entry - risk * 0.5,
     target2: entry - risk,
-    direction: 'Short',
-    strategy: 'Triple Top',
+    qty,
+    atr,
+    spread,
+    liquidity,
     confidence: 0.6,
+    generatedAt: new Date().toISOString(),
+    source: 'strategyTripleTop',
   };
 }
 
 export function strategyVWAPReversal(context = {}) {
-  const { candles = [], features = computeFeatures(candles) } = context;
+  const {
+    candles = [],
+    features = computeFeatures(candles),
+    symbol,
+    accountBalance = 0,
+    riskPerTradePercentage = 0.01,
+    spread = 0,
+    liquidity = 0,
+  } = context;
   if (!Array.isArray(candles) || candles.length < 5) return null;
 
   const atr = features?.atr ?? getATR(candles, 14);
@@ -129,31 +237,105 @@ export function strategyVWAPReversal(context = {}) {
   const stopLoss = pattern.stopLoss;
   const risk = Math.abs(entry - stopLoss);
   const direction = pattern.direction;
+  const qty = calculatePositionSize({
+    capital: accountBalance,
+    risk: accountBalance * riskPerTradePercentage,
+    slPoints: risk,
+    price: entry,
+    volatility: atr,
+  });
 
   return {
+    stock: symbol,
+    strategy: 'VWAP Reversal',
+    pattern: 'VWAP Reversal',
+    direction,
     entry,
     stopLoss,
     target1:
       direction === 'Long' ? entry + risk * 0.5 : entry - risk * 0.5,
     target2:
       direction === 'Long' ? entry + risk : entry - risk,
-    direction,
-    strategy: 'VWAP Reversal',
+    qty,
+    atr,
+    spread,
+    liquidity,
     confidence: 0.55,
+    generatedAt: new Date().toISOString(),
+    source: 'strategyVWAPReversal',
+  };
+}
+
+export function patternBasedStrategy(context = {}) {
+  const {
+    candles = [],
+    features = computeFeatures(candles),
+    symbol,
+    accountBalance = 0,
+    riskPerTradePercentage = 0.01,
+    spread = 0,
+    liquidity = 0,
+  } = context;
+  if (!Array.isArray(candles) || candles.length < 5) return null;
+
+  const atr = features?.atr ?? getATR(candles, 14);
+  const patterns = detectAllPatterns(candles, atr, 5);
+  if (!patterns || patterns.length === 0) return null;
+
+  let best = null;
+  let bestScore = 0;
+  for (const p of patterns) {
+    const score = (p.strength || 1) *
+      (p.confidence === 'High' ? 1 : p.confidence === 'Medium' ? 0.6 : 0.3);
+    if (score > bestScore) {
+      best = p;
+      bestScore = score;
+    }
+  }
+  if (!best) return null;
+
+  const entry = best.breakout;
+  const stopLoss = best.stopLoss;
+  const direction = best.direction;
+  const risk = Math.abs(entry - stopLoss);
+  const qty = calculatePositionSize({
+    capital: accountBalance,
+    risk: accountBalance * riskPerTradePercentage,
+    slPoints: risk,
+    price: entry,
+    volatility: atr,
+  });
+  const target1 = entry + (direction === 'Long' ? 1 : -1) * risk * 1.5;
+  const target2 = entry + (direction === 'Long' ? 1 : -1) * risk * 2;
+
+  return {
+    stock: symbol,
+    strategy: best.type,
+    pattern: best.type,
+    direction,
+    entry,
+    stopLoss,
+    target1,
+    target2,
+    qty,
+    atr,
+    spread,
+    liquidity,
+    confidence: best.confidence,
+    generatedAt: new Date().toISOString(),
+    source: 'patternBasedStrategy',
   };
 }
 
 export function evaluateAllStrategies(context = {}) {
   const strategies = [
+    patternBasedStrategy,
     strategySupertrend,
     strategyEMAReversal,
     strategyTripleTop,
     strategyVWAPReversal,
   ];
-  const results = [];
-  for (const fn of strategies) {
-    const res = fn(context);
-    if (res) results.push(res);
-  }
-  return results;
+  return strategies
+    .map((fn) => fn(context))
+    .filter(Boolean);
 }

--- a/tests/analyzeCandles.test.js
+++ b/tests/analyzeCandles.test.js
@@ -42,10 +42,8 @@ const featureMock = test.mock.module('../featureEngine.js', {
 
 const utilMock = test.mock.module('../util.js', {
   namedExports: {
-    getMAForSymbol: () => 100,
     calculateExpiryMinutes: () => 10,
     debounceSignal: () => true,
-    confirmRetest: () => true,
     detectAllPatterns: () => [
       {
         type: 'Breakout',
@@ -91,7 +89,7 @@ test('analyzeCandles returns a signal for valid data', async () => {
   );
   assert.ok(signal);
   assert.equal(signal.stock, 'TEST');
-  assert.equal(signal.pattern, 'Breakout');
+  assert.equal(signal.strategy, 'Breakout');
   assert.ok(signal.expiresAt);
   assert.equal(signal.support, 90);
   assert.equal(signal.resistance, 110);


### PR DESCRIPTION
## Summary
- shift pattern detection from `scanner.js` into strategy functions
- implement `patternBasedStrategy` and embed signal creation in strategies
- adjust scanner to just call strategies and validate signals
- update tests for new behaviour

## Testing
- `npm test` *(fails: no output - environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_686b8ea754908325afc53533b1eb5c5f