### PR TITLE
Implement margin-aware order checks

### DIFF
--- a/tests/canPlaceTrade.test.js
+++ b/tests/canPlaceTrade.test.js
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+process.env.NODE_ENV = 'test';
+
+const orderMod = await import('../orderExecution.js');
+
+const marginMock = test.mock.method(orderMod, 'getAccountMargin', async () => ({
+  equity: { available: { cash: 10000 } },
+}));
+
+const getMarginMock = test.mock.method(orderMod, 'getMarginForStock', async (
+  order,
+) => ({ required: order.quantity * 5000 }));
+
+const res = await orderMod.canPlaceTrade({ symbol: 'AAA', direction: 'Long' });
+
+getMarginMock.mock.restore();
+marginMock.mock.restore();
+
+test('canPlaceTrade computes quantity using margin', () => {
+  assert.equal(res.canPlace, true);
+  assert.equal(res.quantity, 2);
+});


### PR DESCRIPTION
## Summary
- add `canPlaceTrade` helper in execution layer
- check margin before sending live orders
- test margin-based sizing logic

## Testing
- `npm test` *(fails: Mongo connection not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ca0587e8c8325bc3aca597fed9e32