### PR TITLE
Improve signal generation pipeline

### DIFF
--- a/signalBuilder.js
+++ b/signalBuilder.js
@@ -1,6 +1,9 @@
+import { toISTISOString } from './util.js';
+
 export function buildSignal(context = {}, pattern = {}, tradeParams = {}, confidence = '') {
   const {
     symbol,
+    instrumentToken,
     ma20Val,
     ma50Val,
     ema9,
@@ -32,10 +35,11 @@ export function buildSignal(context = {}, pattern = {}, tradeParams = {}, confid
 
   const { entry, stopLoss, target1, target2, qty } = tradeParams;
 
-  const generatedAt = new Date().toISOString();
+  const generatedAt = toISTISOString();
 
   const signal = {
     stock: symbol,
+    instrument_token: instrumentToken,
     pattern: pattern.type,
     strength: pattern.strength,
     direction: pattern.direction,
@@ -65,13 +69,13 @@ export function buildSignal(context = {}, pattern = {}, tradeParams = {}, confid
     confidenceScore: finalScore,
     liveTickData: liveTick,
     depth,
-    expiresAt,
+    expiresAt: expiresAt ? toISTISOString(expiresAt) : undefined,
     generatedAt,
     source: 'analyzeCandles',
   };
 
   const advancedSignal = {
-    signalId: `${symbol}-1m-${strategyName.replace(/\s+/g, '-')}-${new Date().toISOString().replace(/[:.-]/g, '')}`,
+    signalId: `${symbol}-1m-${strategyName.replace(/\s+/g, '-')}-${toISTISOString().replace(/[:.-]/g, '')}`,
     symbol,
     timeframe: '1m',
     strategy: strategyName,
@@ -94,7 +98,7 @@ export function buildSignal(context = {}, pattern = {}, tradeParams = {}, confid
     confidenceScore: strategyConfidence,
     executionWindow: {
       validFrom: generatedAt,
-      validUntil: expiresAt,
+      validUntil: expiresAt ? toISTISOString(expiresAt) : undefined,
     },
     executionHint: {
       type: 'limitOrMarket',
@@ -103,7 +107,7 @@ export function buildSignal(context = {}, pattern = {}, tradeParams = {}, confid
       strategyRef: `id:${strategyName.toLowerCase().replace(/\s+/g, '-')}`,
     },
     status: 'active',
-    expiresAt,
+    expiresAt: expiresAt ? toISTISOString(expiresAt) : undefined,
     autoCancelOn: [],
   };
 

--- a/util.js
+++ b/util.js
@@ -1,5 +1,11 @@
 // util.js
 import { getMA } from "./kite.js"; // Reuse kite.js
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc.js";
+import timezone from "dayjs/plugin/timezone.js";
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
 import {
   calculateEMA,
   calculateRSI,
@@ -31,6 +37,10 @@ export function calculateMA(prices, length) {
 
 export function getMAForSymbol(symbol, period) {
   return getMA(symbol, period);
+}
+
+export function toISTISOString(date = new Date()) {
+  return dayjs(date).tz("Asia/Kolkata").format();
 }
 
 export function analyzeHigherTimeframe(


### PR DESCRIPTION
## Summary
- support IST timestamps for signals
- integrate advanced strategy evaluation with `strategies.js`
- build enriched signals using all computed metrics

## Testing
- `npm test` *(fails: Mongo connection ENOTFOUND)*

------
https://chatgpt.com/codex/tasks/task_e_686ccdb16c1c8325b65b378eb997ac44