### PR TITLE
Add live metrics and IST handling

### DIFF
--- a/featureEngine.js
+++ b/featureEngine.js
@@ -95,6 +95,7 @@ export function computeFeatures(candles = []) {
   const rsi = calculateRSI(closes, 14);
   const atr = getATR(candles, 14);
   const supertrend = calculateSupertrend(candles, 50);
+  const vwap = calculateVWAP(candles);
 
   const avgVolume =
     volumes.length > 1
@@ -112,5 +113,6 @@ export function computeFeatures(candles = []) {
     supertrend,
     avgVolume,
     rvol,
+    vwap,
   };
 }

--- a/scanner.js
+++ b/scanner.js
@@ -118,6 +118,7 @@ export async function analyzeCandles(
       ema200,
       rsi,
       supertrend,
+      vwap,
       atr: atrValue = 1,
       rvol,
     } = features;
@@ -235,6 +236,8 @@ export async function analyzeCandles(
       depth,
       rrMultiplier: RISK_REWARD_RATIO,
       rvol,
+      vwap,
+      expiryMinutes,
       isUptrend,
       isDowntrend,
       strategyName: base.strategy,

--- a/signalBuilder.js
+++ b/signalBuilder.js
@@ -1,4 +1,8 @@
-import { toISTISOString } from './util.js';
+import {
+  toISTISOString,
+  toISTDate,
+  convertTickTimestampsToIST,
+} from './util.js';
 
 export function buildSignal(context = {}, pattern = {}, tradeParams = {}, confidence = '') {
   const {
@@ -20,6 +24,8 @@ export function buildSignal(context = {}, pattern = {}, tradeParams = {}, confid
     depth,
     rrMultiplier,
     rvol,
+    vwap,
+    expiryMinutes,
     isUptrend,
     isDowntrend,
     strategyName,
@@ -36,6 +42,18 @@ export function buildSignal(context = {}, pattern = {}, tradeParams = {}, confid
   const { entry, stopLoss, target1, target2, qty } = tradeParams;
 
   const generatedAt = toISTISOString();
+  const tickIST = convertTickTimestampsToIST(liveTick);
+  const stockName = symbol.split(':')[1] || symbol;
+  const expiryDate = expiresAt ? toISTDate(expiresAt) : undefined;
+  const expiryMinutesNum =
+    typeof expiryMinutes === 'number'
+      ? expiryMinutes
+      : expiresAt
+      ? Math.round(
+          (new Date(expiresAt).getTime() - new Date(generatedAt).getTime()) /
+            60000
+        )
+      : undefined;
 
   const signal = {
     stock: symbol,
@@ -43,33 +61,40 @@ export function buildSignal(context = {}, pattern = {}, tradeParams = {}, confid
     pattern: pattern.type,
     strength: pattern.strength,
     direction: pattern.direction,
-    entry: parseFloat(entry.toFixed(2)),
-    stopLoss: parseFloat(stopLoss.toFixed(2)),
-    target1: parseFloat(target1.toFixed(2)),
-    target2: parseFloat(target2.toFixed(2)),
+    entry: entry !== undefined ? parseFloat(entry.toFixed(2)) : null,
+    stopLoss: stopLoss !== undefined ? parseFloat(stopLoss.toFixed(2)) : null,
+    target1: target1 !== undefined ? parseFloat(target1.toFixed(2)) : null,
+    target2: target2 !== undefined ? parseFloat(target2.toFixed(2)) : null,
     qty,
-    riskPerUnit: parseFloat(baseRisk.toFixed(2)),
-    riskAmount: parseFloat(riskAmount.toFixed(2)),
-    accountBalance: parseFloat(accountBalance.toFixed(2)),
-    rsi: parseFloat(rsi.toFixed(2)),
+    riskPerUnit: baseRisk !== undefined ? parseFloat(baseRisk.toFixed(2)) : null,
+    riskAmount: riskAmount !== undefined ? parseFloat(riskAmount.toFixed(2)) : null,
+    accountBalance: accountBalance !== undefined ? parseFloat(accountBalance.toFixed(2)) : null,
+    rsi: rsi !== undefined ? parseFloat(rsi.toFixed(2)) : null,
+    liveRSI: rsi !== undefined ? parseFloat(rsi.toFixed(2)) : null,
     ma20: ma20Val !== null ? parseFloat(ma20Val.toFixed(2)) : null,
     ma50: ma50Val !== null ? parseFloat(ma50Val.toFixed(2)) : null,
     support: support !== null ? parseFloat(support.toFixed(2)) : null,
     resistance: resistance !== null ? parseFloat(resistance.toFixed(2)) : null,
-    ema9: parseFloat(ema9.toFixed(2)),
-    ema21: parseFloat(ema21.toFixed(2)),
-    ema50: parseFloat(ema50.toFixed(2)),
-    ema200: parseFloat(ema200.toFixed(2)),
+    ema9: ema9 !== undefined ? parseFloat(ema9.toFixed(2)) : null,
+    ema21: ema21 !== undefined ? parseFloat(ema21.toFixed(2)) : null,
+    ema50: ema50 !== undefined ? parseFloat(ema50.toFixed(2)) : null,
+    ema200: ema200 !== undefined ? parseFloat(ema200.toFixed(2)) : null,
     supertrend,
+    liveVWAP: vwap !== undefined && vwap !== null ? parseFloat(vwap.toFixed(2)) : null,
+    priceDeviation: vwap !== undefined && vwap !== null ? parseFloat((entry - vwap).toFixed(2)) : null,
     atr: atrValue,
     slippage: parseFloat(slippage.toFixed(2)),
     spread: parseFloat(spread.toFixed(2)),
     liquidity,
     confidence,
     confidenceScore: finalScore,
-    liveTickData: liveTick,
+    liveTickData: tickIST,
     depth,
     expiresAt: expiresAt ? toISTISOString(expiresAt) : undefined,
+    expiryDate,
+    expiryMinutes: expiryMinutesNum,
+    stockName,
+    strategy: strategyName,
     generatedAt,
     source: 'analyzeCandles',
   };

--- a/tests/analyzeCandles.test.js
+++ b/tests/analyzeCandles.test.js
@@ -34,7 +34,8 @@ const featureMock = test.mock.module('../featureEngine.js', {
       atr: 2.5,
       supertrend: { signal: 'Buy' },
       avgVolume: 100,
-      rvol: 1.2
+      rvol: 1.2,
+      vwap: 100
     }),
     resetIndicatorCache: () => {}
   }
@@ -53,7 +54,12 @@ const utilMock = test.mock.module('../util.js', {
         strength: 3,
         confidence: 'High'
       }
-    ]
+    ],
+    confirmRetest: () => true,
+    toISTISOString: (d = new Date()) => new Date(d).toISOString(),
+    toISTDate: (d = new Date()) => '2024-01-01',
+    convertTickTimestampsToIST: (t) => t,
+    getMAForSymbol: () => 100
   }
 });
 

--- a/util.js
+++ b/util.js
@@ -43,6 +43,18 @@ export function toISTISOString(date = new Date()) {
   return dayjs(date).tz("Asia/Kolkata").format();
 }
 
+export function toISTDate(date = new Date()) {
+  return dayjs(date).tz("Asia/Kolkata").format("YYYY-MM-DD");
+}
+
+export function convertTickTimestampsToIST(tick = {}) {
+  const t = { ...tick };
+  if (t.last_trade_time) t.last_trade_time = toISTISOString(t.last_trade_time);
+  if (t.exchange_timestamp)
+    t.exchange_timestamp = toISTISOString(t.exchange_timestamp);
+  return t;
+}
+
 export function analyzeHigherTimeframe(
   candles,
   emaLength = 50,


### PR DESCRIPTION
## Summary
- compute VWAP in feature engine
- convert tick timestamps to IST and expose helpers
- include VWAP, RSI, deviation and stock name in built signal
- update analyzeCandles context for VWAP and expiry minutes
- adjust unit tests for new utilities

## Testing
- `npm test` *(fails: analyzeCandles returns a signal for valid data)*

------
https://chatgpt.com/codex/tasks/task_e_686e0cb3b0688325aafe93da69055c73