### PR TITLE
Add volatility indicators

### DIFF
--- a/tests/zzIndicators.test.js
+++ b/tests/zzIndicators.test.js
@@ -7,7 +7,15 @@ import {
   calculateLinearRegression,
   calculateStochastic,
   calculateForceIndex,
-  calculateWilliamsR
+  calculateWilliamsR,
+  calculateStdDev,
+  calculateBollingerBands,
+  calculateKeltnerChannels,
+  calculateDonchianChannels,
+  calculateChaikinVolatility,
+  calculateHistoricalVolatility,
+  calculateFractalChaosBands,
+  calculateEnvelopes
 } from '../featureEngine.js';
 
 test('calculateSMA computes average', () => {
@@ -57,4 +65,71 @@ test('calculateWilliamsR returns number', () => {
   ];
   const wr = calculateWilliamsR(data, 3);
   assert.equal(typeof wr, 'number');
+});
+
+test('calculateStdDev matches expected', () => {
+  const sd = calculateStdDev([1, 2, 3], 3);
+  assert.ok(Math.abs(sd - 0.816496) < 1e-5);
+});
+
+test('calculateBollingerBands returns bands', () => {
+  const bb = calculateBollingerBands([1, 2, 3, 4, 5], 5, 2);
+  assert.ok(bb && Math.abs(bb.middle - 3) < 1e-6);
+});
+
+test('calculateKeltnerChannels returns channels', () => {
+  const candles = [
+    { high: 10, low: 8, close: 9 },
+    { high: 11, low: 9, close: 10 },
+    { high: 12, low: 10, close: 11 },
+    { high: 13, low: 11, close: 12 },
+    { high: 14, low: 12, close: 13 }
+  ];
+  const kc = calculateKeltnerChannels(candles, 3, 2, 1);
+  assert.ok(kc && typeof kc.upper === 'number');
+});
+
+test('calculateDonchianChannels returns channels', () => {
+  const candles = [
+    { high: 10, low: 8 },
+    { high: 11, low: 9 },
+    { high: 12, low: 10 }
+  ];
+  const dc = calculateDonchianChannels(candles, 3);
+  assert.ok(dc && dc.upper === 12 && dc.lower === 8);
+});
+
+test('calculateChaikinVolatility returns number', () => {
+  const candles = [
+    { high: 10, low: 8 },
+    { high: 11, low: 9 },
+    { high: 12, low: 10 },
+    { high: 13, low: 11 },
+    { high: 14, low: 12 },
+    { high: 15, low: 13 }
+  ];
+  const cv = calculateChaikinVolatility(candles, 2, 2);
+  assert.equal(typeof cv, 'number');
+});
+
+test('calculateHistoricalVolatility returns number', () => {
+  const hv = calculateHistoricalVolatility([1, 2, 3, 4, 5], 4, 252);
+  assert.equal(typeof hv, 'number');
+});
+
+test('calculateFractalChaosBands returns bands', () => {
+  const candles = [
+    { high: 10, low: 8 },
+    { high: 12, low: 7 },
+    { high: 11, low: 6 },
+    { high: 13, low: 9 },
+    { high: 12, low: 8 }
+  ];
+  const fcb = calculateFractalChaosBands(candles, 1);
+  assert.ok(fcb && typeof fcb.upper === 'number');
+});
+
+test('calculateEnvelopes returns bands', () => {
+  const env = calculateEnvelopes([1, 2, 3, 4, 5], 5, 0.1);
+  assert.ok(env && typeof env.upper === 'number');
 });

--- a/util.js
+++ b/util.js
@@ -36,6 +36,14 @@ import {
   calculateKlinger,
   calculateSTC,
   calculateTSI,
+  calculateStdDev,
+  calculateBollingerBands,
+  calculateKeltnerChannels,
+  calculateDonchianChannels,
+  calculateChaikinVolatility,
+  calculateHistoricalVolatility,
+  calculateFractalChaosBands,
+  calculateEnvelopes,
   resetIndicatorCache,
 } from "./featureEngine.js";
 
@@ -69,6 +77,14 @@ export {
   calculateKlinger,
   calculateSTC,
   calculateTSI,
+  calculateStdDev,
+  calculateBollingerBands,
+  calculateKeltnerChannels,
+  calculateDonchianChannels,
+  calculateChaikinVolatility,
+  calculateHistoricalVolatility,
+  calculateFractalChaosBands,
+  calculateEnvelopes,
   resetIndicatorCache,
 };
 


### PR DESCRIPTION
## Summary
- implement various volatility indicators like Bollinger Bands, Keltner Channels, Donchian Channels, Chaikin Volatility and more
- expose new indicator helpers via util exports
- add unit tests for new indicator functions

## Testing
- `npm test` *(fails: Mongo connection ENOTFOUND)*

------
https://chatgpt.com/codex/tasks/task_e_6872012bfc188325b2837d21bbaaa3ed