### PR TITLE
Add reversal pattern detection

### DIFF
--- a/tests/patternDetection.test.js
+++ b/tests/patternDetection.test.js
@@ -1,0 +1,52 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const kiteMock = test.mock.module('../kite.js', { namedExports: { getMA: () => null } });
+const dbMock = test.mock.module('../db.js', {
+  defaultExport: {},
+  namedExports: { connectDB: async () => ({}) }
+});
+
+const { detectAllPatterns } = await import('../util.js');
+
+kiteMock.restore();
+dbMock.restore();
+
+test('detectAllPatterns identifies Rounding Bottom', () => {
+  const candles = [
+    { open: 10.8, high: 11, low: 10, close: 10.2 },
+    { open: 10.2, high: 10.5, low: 9.5, close: 9.8 },
+    { open: 9.8, high: 10, low: 9, close: 9.5 },
+    { open: 9.6, high: 10.4, low: 9.3, close: 10.1 },
+    { open: 10.2, high: 11.2, low: 9.8, close: 11 }
+  ];
+  const patterns = detectAllPatterns(candles, 1, 5);
+  const rb = patterns.find(p => p.type === 'Rounding Bottom');
+  assert.ok(rb);
+});
+
+test('detectAllPatterns identifies Broadening Top', () => {
+  const candles = [
+    { open: 9, high: 9.2, low: 8.9, close: 9.1 },
+    { open: 9.2, high: 9.4, low: 8.8, close: 9 },
+    { open: 9.5, high: 10, low: 9, close: 9.8 },
+    { open: 9.8, high: 11, low: 8.8, close: 9 },
+    { open: 9, high: 12, low: 8, close: 8.5 }
+  ];
+  const patterns = detectAllPatterns(candles, 1, 5);
+  const bt = patterns.find(p => p.type === 'Broadening Top');
+  assert.ok(bt);
+});
+
+test('detectAllPatterns identifies Saucer Bottom', () => {
+  const candles = [
+    { open: 9.8, high: 10, low: 9.7, close: 9.9 },
+    { open: 9.9, high: 10.1, low: 9.6, close: 9.8 },
+    { open: 10, high: 10.2, low: 9, close: 9 },
+    { open: 9.5, high: 9.7, low: 9, close: 9 },
+    { open: 9.1, high: 10.5, low: 9, close: 10 }
+  ];
+  const patterns = detectAllPatterns(candles, 1, 5);
+  const sb = patterns.find(p => p.type === 'Saucer Bottom');
+  assert.ok(sb);
+});

--- a/util.js
+++ b/util.js
@@ -651,6 +651,113 @@ export function detectAllPatterns(candles, atrValue, lookback = 5) {
     });
   }
 
+  if (lastN.length >= 5) {
+    const isRoundingTop =
+      highs[0] < highs[1] &&
+      highs[1] < highs[2] &&
+      highs[2] > highs[3] &&
+      highs[3] > highs[4] &&
+      lows[0] < lows[1] &&
+      lows[1] < lows[2] &&
+      lows[2] > lows[3] &&
+      lows[3] > lows[4];
+
+    if (isRoundingTop) {
+      patterns.push({
+        type: "Rounding Top",
+        direction: "Short",
+        breakout: recentLow,
+        stopLoss: highs[2],
+        strength: 2,
+        confidence: "Medium",
+      });
+    }
+
+    const isRoundingBottom =
+      highs[0] > highs[1] &&
+      highs[1] > highs[2] &&
+      highs[2] < highs[3] &&
+      highs[3] < highs[4] &&
+      lows[0] > lows[1] &&
+      lows[1] > lows[2] &&
+      lows[2] < lows[3] &&
+      lows[3] < lows[4];
+
+    if (isRoundingBottom) {
+      patterns.push({
+        type: "Rounding Bottom",
+        direction: "Long",
+        breakout: recentHigh,
+        stopLoss: lows[2],
+        strength: 2,
+        confidence: "Medium",
+      });
+    }
+  }
+
+  if (candles.length >= 3) {
+    const [a, b, c] = candles.slice(-3);
+    const rangeA = a.high - a.low;
+    const rangeB = b.high - b.low;
+    const rangeC = c.high - c.low;
+
+    const broadeningTop =
+      c.high > b.high &&
+      b.high > a.high &&
+      c.low < b.low &&
+      b.low < a.low &&
+      rangeB > rangeA &&
+      rangeC > rangeB;
+
+    if (broadeningTop) {
+      patterns.push({
+        type: "Broadening Top",
+        direction: "Short",
+        breakout: c.low,
+        stopLoss: c.high,
+        strength: 2,
+        confidence: "Medium",
+      });
+    }
+
+    const broadeningBottom =
+      c.high < b.high &&
+      b.high < a.high &&
+      c.low > b.low &&
+      b.low > a.low &&
+      rangeB > rangeA &&
+      rangeC > rangeB;
+
+    if (broadeningBottom) {
+      patterns.push({
+        type: "Broadening Bottom",
+        direction: "Long",
+        breakout: c.high,
+        stopLoss: c.low,
+        strength: 2,
+        confidence: "Medium",
+      });
+    }
+
+    const saucerBottom =
+      a.close < a.open &&
+      b.close < b.open &&
+      b.low >= a.low &&
+      c.close > c.open &&
+      c.close > b.close;
+
+    if (saucerBottom) {
+      patterns.push({
+        type: "Saucer Bottom",
+        direction: "Long",
+        breakout: c.high,
+        stopLoss: Math.min(a.low, b.low),
+        strength: 1,
+        confidence: "Medium",
+      });
+    }
+  }
+
   const isRising =
     lows[0] < lows[1] &&
     lows[1] < lows[2] &&


### PR DESCRIPTION
## Summary
- extend `detectAllPatterns` with detection logic for Rounding Top, Rounding Bottom, Broadening Top, Broadening Bottom, and Saucer Bottom
- add new tests verifying detection of these patterns

## Testing
- `npm test` *(fails: analyzeCandles returns a signal for valid data, canPlaceTrade.test.js, confidence.test.js, positionSizing.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68738a1143d48325a842e7368f88dd36