### PR TITLE
Add swing trading pattern detection

### DIFF
--- a/tests/patternDetection.test.js
+++ b/tests/patternDetection.test.js
@@ -85,3 +85,28 @@ test('detectAllPatterns identifies Swing Failure Pattern (Bearish)', () => {
   const sfp = patterns.find(p => p.type === 'Swing Failure Pattern (Bearish)');
   assert.ok(sfp);
 });
+
+test('detectAllPatterns identifies Wolfe Wave (Bullish)', () => {
+  const candles = [
+    { open: 10, high: 10.2, low: 9.8, close: 10.1 },
+    { open: 9.9, high: 10, low: 9.6, close: 9.7 },
+    { open: 10, high: 10.3, low: 9.8, close: 10.2 },
+    { open: 9.8, high: 10, low: 9.4, close: 9.6 },
+    { open: 10.1, high: 10.6, low: 9.9, close: 10.5 }
+  ];
+  const patterns = detectAllPatterns(candles, 1, 5);
+  const ww = patterns.find(p => p.type === 'Wolfe Wave (Bullish)');
+  assert.ok(ww);
+});
+
+test('detectAllPatterns identifies Dead Cat Bounce', () => {
+  const candles = [
+    { open: 12, high: 12.1, low: 11.8, close: 12 },
+    { open: 10.5, high: 10.8, low: 10.2, close: 10.4 },
+    { open: 10.8, high: 11, low: 10.3, close: 10.8 },
+    { open: 10.6, high: 10.7, low: 10.1, close: 10.2 }
+  ];
+  const patterns = detectAllPatterns(candles, 1, 4);
+  const dcb = patterns.find(p => p.type === 'Dead Cat Bounce');
+  assert.ok(dcb);
+});


### PR DESCRIPTION
## Summary
- implement additional swing trading pattern detection
- expand test coverage for new patterns

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68744e72d33c8325800a1c45e21e8902