### PR TITLE
Add gap reversal pattern detectors

### DIFF
--- a/strategies.js
+++ b/strategies.js
@@ -1187,6 +1187,70 @@ function detectGapDownRetestGapZone(candles) {
   return null;
 }
 
+function detectGapFillReversal(candles) {
+  if (candles.length < 2) return null;
+  const prev = candles.at(-2);
+  const last = candles.at(-1);
+  const gap = (last.open - prev.close) / prev.close;
+  if (gap > 0.015 && last.close < prev.close) {
+    return { name: "Gap Fill Reversal (Bearish)", confidence: 0.55 };
+  }
+  if (gap < -0.015 && last.close > prev.close) {
+    return { name: "Gap Fill Reversal (Bullish)", confidence: 0.55 };
+  }
+  return null;
+}
+
+function detectIslandReversalTop(candles) {
+  if (candles.length < 3) return null;
+  const [a, b, c] = candles.slice(-3);
+  if (b.low > a.high && c.high < b.low) {
+    return { name: "Island Reversal Top", confidence: 0.55 };
+  }
+  return null;
+}
+
+function detectIslandReversalBottom(candles) {
+  if (candles.length < 3) return null;
+  const [a, b, c] = candles.slice(-3);
+  if (b.high < a.low && c.low > b.high) {
+    return { name: "Island Reversal Bottom", confidence: 0.55 };
+  }
+  return null;
+}
+
+function detectBullTrapAfterGapUp(candles) {
+  if (candles.length < 2) return null;
+  const prev = candles.at(-2);
+  const last = candles.at(-1);
+  const gap = (last.open - prev.close) / prev.close;
+  if (
+    gap > 0.015 &&
+    last.high > prev.high &&
+    last.close < prev.high &&
+    last.close < last.open
+  ) {
+    return { name: "Bull Trap After Gap Up", confidence: 0.55 };
+  }
+  return null;
+}
+
+function detectBearTrapAfterGapDown(candles) {
+  if (candles.length < 2) return null;
+  const prev = candles.at(-2);
+  const last = candles.at(-1);
+  const gap = (last.open - prev.close) / prev.close;
+  if (
+    gap < -0.015 &&
+    last.low < prev.low &&
+    last.close > prev.low &&
+    last.close > last.open
+  ) {
+    return { name: "Bear Trap After Gap Down", confidence: 0.55 };
+  }
+  return null;
+}
+
 function detectParabolicExhaustion(
   candles,
   _ctx = {},
@@ -1446,6 +1510,11 @@ export const DETECTORS = [
   detectGapDownTrendlineBreakdown,
   detectGapDownHeadShouldersBreakdown,
   detectGapDownRetestGapZone,
+  detectGapFillReversal,
+  detectIslandReversalTop,
+  detectIslandReversalBottom,
+  detectBullTrapAfterGapUp,
+  detectBearTrapAfterGapDown,
 ];
 
 export function evaluateStrategies(
@@ -1562,6 +1631,30 @@ export const reversalStrategies = [
       "Dark Cloud Cover (bearish) or Piercing Line (bullish)",
       "Volume and location near support/resistance improve reliability",
     ],
+  },
+  {
+    name: "Gap Fill Reversal (Bearish)",
+    rules: ["Gap up fades and closes below prior close"],
+  },
+  {
+    name: "Gap Fill Reversal (Bullish)",
+    rules: ["Gap down fills and closes above prior close"],
+  },
+  {
+    name: "Island Reversal Top",
+    rules: ["Gap up followed by gap down creating an island"],
+  },
+  {
+    name: "Island Reversal Bottom",
+    rules: ["Gap down followed by gap up creating an island"],
+  },
+  {
+    name: "Bull Trap After Gap Up",
+    rules: ["Gap up above prior high then reverses lower"],
+  },
+  {
+    name: "Bear Trap After Gap Down",
+    rules: ["Gap down below prior low then reverses higher"],
   },
 ];
 

--- a/tests/newPatterns.test.js
+++ b/tests/newPatterns.test.js
@@ -122,3 +122,55 @@ test('Gap Down + Trendline Breakdown detected', () => {
   const found = res.find(r => r.name === 'Gap Down + Trendline Breakdown');
   assert.ok(found);
 });
+
+test('Gap Fill Reversal (Bearish) detected', () => {
+  const candles = [
+    { open: 100, high: 101, low: 99, close: 100, volume: 100 },
+    { open: 103, high: 104, low: 98, close: 99, volume: 120 }
+  ];
+  const res = evaluateStrategies(candles, {}, { topN: 5 });
+  const found = res.find(r => r.name === 'Gap Fill Reversal (Bearish)');
+  assert.ok(found);
+});
+
+test('Island Reversal Top detected', () => {
+  const candles = [
+    { open: 100, high: 101, low: 99, close: 100, volume: 100 },
+    { open: 102, high: 103, low: 102, close: 102.5, volume: 100 },
+    { open: 100, high: 100.5, low: 99.5, close: 100, volume: 100 }
+  ];
+  const res = evaluateStrategies(candles, {}, { topN: 5 });
+  const found = res.find(r => r.name === 'Island Reversal Top');
+  assert.ok(found);
+});
+
+test('Island Reversal Bottom detected', () => {
+  const candles = [
+    { open: 100, high: 101, low: 99, close: 100, volume: 100 },
+    { open: 98, high: 98.5, low: 97.5, close: 98, volume: 100 },
+    { open: 100, high: 101, low: 99.5, close: 100.5, volume: 100 }
+  ];
+  const res = evaluateStrategies(candles, {}, { topN: 5 });
+  const found = res.find(r => r.name === 'Island Reversal Bottom');
+  assert.ok(found);
+});
+
+test('Bull Trap After Gap Up detected', () => {
+  const candles = [
+    { open: 100, high: 101, low: 99, close: 101, volume: 100 },
+    { open: 103, high: 104, low: 99, close: 100, volume: 110 }
+  ];
+  const res = evaluateStrategies(candles, {}, { topN: 5 });
+  const found = res.find(r => r.name === 'Bull Trap After Gap Up');
+  assert.ok(found);
+});
+
+test('Bear Trap After Gap Down detected', () => {
+  const candles = [
+    { open: 100, high: 101, low: 99, close: 99, volume: 100 },
+    { open: 97, high: 100, low: 95, close: 99.5, volume: 110 }
+  ];
+  const res = evaluateStrategies(candles, {}, { topN: 5 });
+  const found = res.find(r => r.name === 'Bear Trap After Gap Down');
+  assert.ok(found);
+});

--- a/tests/patternDetection.test.js
+++ b/tests/patternDetection.test.js
@@ -110,3 +110,55 @@ test('detectAllPatterns identifies Dead Cat Bounce', () => {
   const dcb = patterns.find(p => p.type === 'Dead Cat Bounce');
   assert.ok(dcb);
 });
+
+test('detectAllPatterns identifies Gap Fill Reversal (Bearish)', () => {
+  const candles = [
+    { open: 100, high: 101, low: 99, close: 100 },
+    { open: 103, high: 104, low: 98, close: 99 }
+  ];
+  const patterns = detectAllPatterns(candles, 1, 2);
+  const gfr = patterns.find(p => p.type === 'Gap Fill Reversal (Bearish)');
+  assert.ok(gfr);
+});
+
+test('detectAllPatterns identifies Island Reversal Top', () => {
+  const candles = [
+    { open: 100, high: 101, low: 99, close: 100 },
+    { open: 102, high: 103, low: 102, close: 102.5 },
+    { open: 100, high: 100.5, low: 99.5, close: 100 }
+  ];
+  const patterns = detectAllPatterns(candles, 1, 3);
+  const irt = patterns.find(p => p.type === 'Island Reversal Top');
+  assert.ok(irt);
+});
+
+test('detectAllPatterns identifies Island Reversal Bottom', () => {
+  const candles = [
+    { open: 100, high: 101, low: 99, close: 100 },
+    { open: 98, high: 98.5, low: 97.5, close: 98 },
+    { open: 100, high: 101, low: 99.5, close: 100.5 }
+  ];
+  const patterns = detectAllPatterns(candles, 1, 3);
+  const irb = patterns.find(p => p.type === 'Island Reversal Bottom');
+  assert.ok(irb);
+});
+
+test('detectAllPatterns identifies Bull Trap After Gap Up', () => {
+  const candles = [
+    { open: 100, high: 101, low: 99, close: 101 },
+    { open: 103, high: 104, low: 99, close: 100 }
+  ];
+  const patterns = detectAllPatterns(candles, 1, 2);
+  const bt = patterns.find(p => p.type === 'Bull Trap After Gap Up');
+  assert.ok(bt);
+});
+
+test('detectAllPatterns identifies Bear Trap After Gap Down', () => {
+  const candles = [
+    { open: 100, high: 101, low: 99, close: 99 },
+    { open: 97, high: 100, low: 95, close: 99.5 }
+  ];
+  const patterns = detectAllPatterns(candles, 1, 2);
+  const bt = patterns.find(p => p.type === 'Bear Trap After Gap Down');
+  assert.ok(bt);
+});

--- a/util.js
+++ b/util.js
@@ -1564,9 +1564,21 @@ export function detectAllPatterns(candles, atrValue, lookback = 5) {
         strength: 2,
         confidence: "Low",
       });
+      patterns.push({
+        type: "Island Reversal Top",
+        direction: "Short",
+        strength: 2,
+        confidence: "Low",
+      });
     } else if (gapDown) {
       patterns.push({
         type: "Island Reversal (Bullish)",
+        direction: "Long",
+        strength: 2,
+        confidence: "Low",
+      });
+      patterns.push({
+        type: "Island Reversal Bottom",
         direction: "Long",
         strength: 2,
         confidence: "Low",
@@ -1598,6 +1610,16 @@ export function detectAllPatterns(candles, atrValue, lookback = 5) {
         strength: 2,
         confidence: "Low",
       });
+      const prevClose = b1.close;
+      const gap = (b2.open - prevClose) / prevClose;
+      if (gap > 0.015 && b3.close < b1.high && b3.close < b2.open) {
+        patterns.push({
+          type: "Bull Trap After Gap Up",
+          direction: "Short",
+          strength: 2,
+          confidence: "Medium",
+        });
+      }
     }
     if (b2.low < Math.min(b1.low, b3.low) && b3.close > b1.close) {
       patterns.push({
@@ -1605,6 +1627,38 @@ export function detectAllPatterns(candles, atrValue, lookback = 5) {
         direction: "Long",
         strength: 2,
         confidence: "Low",
+      });
+      const prevClose = b1.close;
+      const gap = (b2.open - prevClose) / prevClose;
+      if (gap < -0.015 && b3.close > b1.low && b3.close > b2.open) {
+        patterns.push({
+          type: "Bear Trap After Gap Down",
+          direction: "Long",
+          strength: 2,
+          confidence: "Medium",
+        });
+      }
+    }
+  }
+
+  if (candles.length >= 2) {
+    const prev = candles[candles.length - 2];
+    const last = candles[candles.length - 1];
+    const gap = (last.open - prev.close) / prev.close;
+    if (gap > 0.015 && last.close < prev.close && last.close < last.open) {
+      patterns.push({
+        type: "Gap Fill Reversal (Bearish)",
+        direction: "Short",
+        strength: 2,
+        confidence: "Medium",
+      });
+    }
+    if (gap < -0.015 && last.close > prev.close && last.close > last.open) {
+      patterns.push({
+        type: "Gap Fill Reversal (Bullish)",
+        direction: "Long",
+        strength: 2,
+        confidence: "Medium",
       });
     }
   }


### PR DESCRIPTION
## Summary
- add additional gap reversal pattern recognition in `util.js`
- implement related detectors in `strategies.js`
- register new strategies and detection logic
- extend tests for new patterns

## Testing
- `npm test` *(fails: Mongo connection issue)*

------
https://chatgpt.com/codex/tasks/task_e_68745fad13448325a57207a8355aaf3b