### PR TITLE
Add basic risk validators

### DIFF
--- a/riskEngine.js
+++ b/riskEngine.js
@@ -1,6 +1,12 @@
 // riskEngine.js
 // Central risk validation engine for trading signals
-import { validateRR, checkMarketConditions } from './riskValidator.js';
+import {
+  validateRR,
+  checkMarketConditions,
+  validateATRStopLoss,
+  validateSupportResistance,
+  validateVolumeSpike,
+} from './riskValidator.js';
 
 const defaultState = {
   dailyLoss: 0,
@@ -46,6 +52,30 @@ export function isSignalValid(signal, ctx = {}) {
   });
   if (!rr.valid) return false;
   if (typeof ctx.minRR === 'number' && rr.rr < ctx.minRR) return false;
+
+  if (
+    !validateATRStopLoss({ entry: signal.entry, stopLoss: signal.stopLoss, atr: signal.atr })
+  )
+    return false;
+
+  if (
+    !validateSupportResistance({
+      entry: signal.entry,
+      direction: signal.direction,
+      support: signal.support,
+      resistance: signal.resistance,
+      atr: signal.atr,
+    })
+  )
+    return false;
+
+  if (
+    !validateVolumeSpike({
+      volume: signal.volume ?? ctx.volume,
+      avgVolume: ctx.avgVolume,
+    })
+  )
+    return false;
 
   if (typeof ctx.minATR === 'number' && signal.atr < ctx.minATR) return false;
   if (typeof ctx.maxATR === 'number' && signal.atr > ctx.maxATR) return false;

--- a/riskValidator.js
+++ b/riskValidator.js
@@ -56,6 +56,48 @@ export function isSLInvalid({ price, stopLoss, atr, structureBreak = false }) {
   return proximity <= atr * 0.2;
 }
 
+// Ensure stop-loss distance is sensible relative to ATR
+export function validateATRStopLoss({
+  entry,
+  stopLoss,
+  atr,
+  minMult = 0.5,
+  maxMult = 3,
+}) {
+  if (!atr) return true;
+  const dist = Math.abs(entry - stopLoss);
+  if (dist <= atr * minMult) return false;
+  if (dist > atr * maxMult) return false;
+  return true;
+}
+
+// Validate trade entry against nearest support/resistance levels
+export function validateSupportResistance({
+  entry,
+  direction,
+  support,
+  resistance,
+  atr,
+}) {
+  const buffer = atr ? atr * 0.5 : entry * 0.01;
+  if (direction === 'Long') {
+    if (typeof support === 'number' && entry - support <= buffer) return false;
+    if (typeof resistance === 'number' && resistance - entry <= buffer)
+      return false;
+  } else if (direction === 'Short') {
+    if (typeof resistance === 'number' && resistance - entry <= buffer)
+      return false;
+    if (typeof support === 'number' && entry - support <= buffer) return false;
+  }
+  return true;
+}
+
+// Require current volume to exceed average volume by a multiplier
+export function validateVolumeSpike({ volume, avgVolume, minSpike = 1.5 }) {
+  if (!volume || !avgVolume) return true;
+  return volume >= avgVolume * minSpike;
+}
+
 export function checkMarketConditions({
   atr,
   avgAtr,

--- a/tests/newValidators.test.js
+++ b/tests/newValidators.test.js
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const auditMock = test.mock.module('../auditLogger.js', { namedExports: { logSignalRejected: () => {} } });
+const dbMock = test.mock.module('../db.js', { defaultExport: {}, namedExports: { connectDB: async () => ({}) } });
+
+const {
+  validateATRStopLoss,
+  validateSupportResistance,
+  validateVolumeSpike,
+} = await import('../riskValidator.js');
+
+auditMock.restore();
+dbMock.restore();
+
+test('validateATRStopLoss enforces min and max distance', () => {
+  assert.equal(validateATRStopLoss({ entry: 100, stopLoss: 99, atr: 2 }), false);
+  assert.equal(validateATRStopLoss({ entry: 100, stopLoss: 85, atr: 2 }), false);
+  assert.equal(validateATRStopLoss({ entry: 100, stopLoss: 96, atr: 2 }), true);
+});
+
+test('validateSupportResistance respects levels', () => {
+  assert.equal(
+    validateSupportResistance({ entry: 105, direction: 'Long', support: 104, resistance: 106, atr: 2 }),
+    false
+  );
+  assert.equal(
+    validateSupportResistance({ entry: 100, direction: 'Short', support: 98, resistance: 102, atr: 2 }),
+    true
+  );
+  assert.equal(
+    validateSupportResistance({ entry: 110, direction: 'Long', support: 105, resistance: 120, atr: 2 }),
+    true
+  );
+});
+
+test('validateVolumeSpike requires spike over average', () => {
+  assert.equal(validateVolumeSpike({ volume: 150, avgVolume: 100 }), true);
+  assert.equal(validateVolumeSpike({ volume: 120, avgVolume: 100, minSpike: 1.3 }), false);
+});


### PR DESCRIPTION
## Summary
- implement additional risk validators: ATR-based stop-loss, support/resistance distance and volume spike checks
- integrate new validators in `riskEngine`
- test new validator utilities

## Testing
- `node --test --experimental-test-module-mocks tests/newValidators.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68747159c3f08325981ce3f227507cc5