### PR TITLE
Enhance position sizing utilities

### DIFF
--- a/tests/analyzeCandles.test.js
+++ b/tests/analyzeCandles.test.js
@@ -59,7 +59,8 @@ const utilMock = test.mock.module('../util.js', {
     toISTISOString: (d = new Date()) => new Date(d).toISOString(),
     toISTDate: (d = new Date()) => '2024-01-01',
     convertTickTimestampsToIST: (t) => t,
-    getMAForSymbol: () => 100
+    getMAForSymbol: () => 100,
+    DEFAULT_MARGIN_PERCENT: 0.2
   }
 });
 

--- a/tests/newPatterns.test.js
+++ b/tests/newPatterns.test.js
@@ -12,7 +12,13 @@ const featureMock = test.mock.module('../featureEngine.js', {
     computeFeatures: () => ({ ema9: 0, ema21: 0, ema200: 0, rsi: 50 })
   }
 });
-const utilMock = test.mock.module('../util.js', { namedExports: { confirmRetest: () => true, detectAllPatterns: () => [] } });
+const utilMock = test.mock.module('../util.js', {
+  namedExports: {
+    confirmRetest: () => true,
+    detectAllPatterns: () => [],
+    DEFAULT_MARGIN_PERCENT: 0.2,
+  }
+});
 const dbMock = test.mock.module('../db.js', { defaultExport: {}, namedExports: { connectDB: async () => ({}) } });
 
 const { evaluateStrategies } = await import('../strategies.js');

--- a/tests/positionSizing.test.js
+++ b/tests/positionSizing.test.js
@@ -2,7 +2,17 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 process.env.NODE_ENV = 'test';
 
-import { calculatePositionSize } from '../positionSizing.js';
+const dbMock = test.mock.module('../db.js', {
+  defaultExport: {},
+  namedExports: { connectDB: async () => ({}) }
+});
+const kiteMock = test.mock.module('../kite.js', { namedExports: { getMA: () => null } });
+
+const { calculatePositionSize } = await import('../positionSizing.js');
+const { atrStopLossDistance, calculateRequiredMargin } = await import('../util.js');
+
+kiteMock.restore();
+dbMock.restore();
 
 // Example from docs: ₹10,000 risk, 15 point SL, lot size 330 => 660 qty
 
@@ -15,5 +25,27 @@ test('calculatePositionSize computes lot size correctly', () => {
     volatility: 2,
   });
   assert.equal(qty, 660);
+});
+
+test('atrStopLossDistance returns atr multiple', () => {
+  const dist = atrStopLossDistance(2, 'breakout');
+  assert.equal(dist, 4);
+});
+
+test('calculateRequiredMargin uses leverage', () => {
+  const margin = calculateRequiredMargin({ price: 100, qty: 10, leverage: 5 });
+  assert.equal(margin, 200);
+});
+
+test('leverage limits position size', () => {
+  const qty = calculatePositionSize({
+    capital: 10000,
+    risk: 5000,
+    slPoints: 1,
+    price: 100,
+    leverage: 1,
+  });
+  // Without leverage restriction qty would be 5000
+  assert.equal(qty, 100); // capped by margin
 });
 


### PR DESCRIPTION
## Summary
- add DEFAULT_MARGIN_PERCENT and new helper utilities in `util.js`
- support leverage and broker margin parameters in `positionSizing.js`
- expose new ATR-based distance and margin calculation functions
- extend position sizing tests and update existing mocks
- update related test mocks for new exports

## Testing
- `npm test` *(fails: ERR_TEST_FAILURE in multiple pattern detection tests)*

------
https://chatgpt.com/codex/tasks/task_e_68747666403c832595e84303d52988ed