### PR TITLE
Fix invalid date handling in session code

### DIFF
--- a/kite.js
+++ b/kite.js
@@ -1094,6 +1094,7 @@ function computeGapPercent(tokenStr) {
 function isSameDay(d1, d2) {
   const a = new Date(d1);
   const b = new Date(d2);
+  if (isNaN(a) || isNaN(b)) return false;
   return a.toISOString().slice(0, 10) === b.toISOString().slice(0, 10);
 }
 


### PR DESCRIPTION
## Summary
- avoid crashes when dates can't be parsed

## Testing
- `npm test` *(fails: tests hang)*

------
https://chatgpt.com/codex/tasks/task_e_6874844b1f848325b9db8f88d8a1d695