### PR TITLE
Implement advanced risk controls

### DIFF
--- a/positionSizing.js
+++ b/positionSizing.js
@@ -44,6 +44,8 @@ export function calculatePositionSize({
   volatilityGuard,
   marketDepth,
   priceMovement,
+  minQty,
+  maxQty,
 }) {
   if (!capital || !slPoints || slPoints <= 0) return 0;
 
@@ -97,6 +99,9 @@ export function calculatePositionSize({
     const maxLots = Math.floor((capital * utilizationCap) / effectiveMarginPerLot);
     qty = Math.min(qty, maxLots * lotSize);
   }
+
+  if (typeof minQty === 'number' && qty < minQty) return 0;
+  if (typeof maxQty === 'number' && qty > maxQty) qty = maxQty;
 
   return qty > 0 ? qty : lotSize;
 }

--- a/tests/positionSizing.test.js
+++ b/tests/positionSizing.test.js
@@ -49,3 +49,14 @@ test('leverage limits position size', () => {
   assert.equal(qty, 100); // capped by margin
 });
 
+test('min and max qty constraints applied', () => {
+  const qty = calculatePositionSize({
+    capital: 100000,
+    risk: 1000,
+    slPoints: 10,
+    minQty: 20,
+    maxQty: 50,
+  });
+  assert.equal(qty, 50);
+});
+


### PR DESCRIPTION
## Summary
- expand `riskEngine` with daily risk, loss streak, trade value and position count checks
- enforce min/max quantity in `calculatePositionSize`
- gate execution in `tradeLifecycle` with new risk parameters
- test new risk engine and position sizing behaviours

## Testing
- `npm test` *(fails: Mongo connection)*

------
https://chatgpt.com/codex/tasks/task_e_687483d47c8483258b89a025cffc81f1