### PR TITLE
Fix analyzeCandles undefined candle crash

### DIFF
--- a/scanner.js
+++ b/scanner.js
@@ -86,8 +86,14 @@ export async function analyzeCandles(
       return null;
     }
 
+    // Filter out malformed candle objects
     const validCandles = candles.filter(
-      (c) => c.open && c.high && c.low && c.close
+      (c) =>
+        c &&
+        c.open !== undefined &&
+        c.high !== undefined &&
+        c.low !== undefined &&
+        c.close !== undefined
     );
     if (validCandles.length < 5) return null;
     const features = computeFeatures(validCandles);


### PR DESCRIPTION
## Summary
- handle malformed candle data before feature calculation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6875ddc429048325b4454d951a5fc646