### PR TITLE
Add advanced position sizing models

### DIFF
--- a/tests/positionSizing.test.js
+++ b/tests/positionSizing.test.js
@@ -8,7 +8,11 @@ const dbMock = test.mock.module('../db.js', {
 });
 const kiteMock = test.mock.module('../kite.js', { namedExports: { getMA: () => null } });
 
-const { calculatePositionSize } = await import('../positionSizing.js');
+const {
+  calculatePositionSize,
+  kellyCriterionSize,
+  equalCapitalAllocation,
+} = await import('../positionSizing.js');
 const { atrStopLossDistance, calculateRequiredMargin } = await import('../util.js');
 
 kiteMock.restore();
@@ -80,5 +84,20 @@ test('costBuffer scales risk amount', () => {
     costBuffer: 1.1,
   });
   assert.equal(qty, 90);
+});
+
+test('kellyCriterionSize computes fraction', () => {
+  const qty = kellyCriterionSize({
+    capital: 100000,
+    winRate: 0.6,
+    winLossRatio: 2,
+    slPoints: 10,
+  });
+  assert.equal(qty, 4000);
+});
+
+test('equalCapitalAllocation splits capital', () => {
+  const qty = equalCapitalAllocation({ capital: 100000, numPositions: 5, price: 100 });
+  assert.equal(qty, 200);
 });
 


### PR DESCRIPTION
## Summary
- implement several position sizing models (rupee, percent, Kelly, volatility-weighted, equal capital, equal risk, confidence based, ATR, dollar volatility)
- allow `calculatePositionSize` to select among methods
- cover new helpers with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876512c67d0832588653ef7b8831713