### PR TITLE
Implement advanced capital exposure checks

### DIFF
--- a/tradeLifecycle.js
+++ b/tradeLifecycle.js
@@ -93,6 +93,14 @@ export async function executeSignal(signal, opts = {}) {
       tradeValue,
       sector: signal.sector || 'GEN',
       totalCapital: opts.totalCapital || opts.capital || 0,
+      sectorCaps: opts.sectorCaps,
+      exposureCap: opts.exposureCap,
+      instrumentCap: opts.instrumentCap,
+      tradeCapPct: opts.tradeCapPct,
+      reservePct: opts.reservePct,
+      maxMarginPct: opts.maxMarginPct,
+      minTradeCapital: opts.minTradeCapital,
+      maxTradeCapital: opts.maxTradeCapital,
     }) &&
     preventReEntry(symbol) &&
     resolveSignalConflicts({


### PR DESCRIPTION
## Summary
- extend portfolio exposure filters to support capital and margin constraints
- pass new risk parameters from trade execution

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687665c6c9f083259b2d77e670345776