### PR TITLE
Implement trade count filters and conflict checks

### DIFF
--- a/tradeLifecycle.js
+++ b/tradeLifecycle.js
@@ -1,6 +1,6 @@
 // tradeLifecycle.js
 import { sendOrder, cancelOrder, getAllOrders } from './orderExecution.js';
-import { isSignalValid } from './riskEngine.js';
+import { isSignalValid, recordTradeExecution } from './riskEngine.js';
 import { calculatePositionSize } from './positionSizing.js';
 import {
   checkExposureLimits,
@@ -84,6 +84,7 @@ export async function executeSignal(signal, opts = {}) {
       newTradeQty: qty,
       preventOverlap: true,
       openSymbols: Array.from(openPositions.keys()),
+      openPositionsMap: openPositions,
     })
   )
     return null;
@@ -122,6 +123,7 @@ export async function executeSignal(signal, opts = {}) {
   if (!entryOrder) return null;
   const filled = await waitForOrderFill(entryOrder.order_id);
   if (!filled) return null;
+  recordTradeExecution({ symbol, sector: signal.sector });
 
   const exitType = signal.direction === 'Long' ? 'SELL' : 'BUY';
   const slOrder = await sendOrder('regular', {


### PR DESCRIPTION
## Summary
- enforce daily instrument and sector trade limits
- record executed trades for tracking
- block conflicts with open positions
- update trade lifecycle to log executions
- test new risk engine checks

## Testing
- `npm test` *(fails: Mongo connection errors)*

------
https://chatgpt.com/codex/tasks/task_e_68767172a5688325b75b2129c5cd7abf