### PR TITLE
Implement advanced risk filters

### DIFF
--- a/tests/riskEngine.test.js
+++ b/tests/riskEngine.test.js
@@ -176,3 +176,36 @@ test('isSignalValid blocks opposite direction with open position', () => {
   const ok = isSignalValid(sig, { openPositionsMap: positions });
   assert.equal(ok, false);
 });
+
+test('isSignalValid enforces cooloff after loss', () => {
+  resetRiskState();
+  riskState.lastTradeWasLoss = true;
+  const sig = {
+    stock: 'FFF',
+    pattern: 'trend',
+    direction: 'Long',
+    entry: 100,
+    stopLoss: 98,
+    target2: 104,
+    atr: 1,
+    spread: 0.1,
+  };
+  const ok = isSignalValid(sig, { cooloffAfterLoss: true });
+  assert.equal(ok, false);
+});
+
+test('isSignalValid enforces maxLossPerTradePct', () => {
+  resetRiskState();
+  const sig = {
+    stock: 'GGG',
+    pattern: 'trend',
+    direction: 'Long',
+    entry: 100,
+    stopLoss: 90,
+    target2: 120,
+    atr: 1,
+    spread: 0.1,
+  };
+  const ok = isSignalValid(sig, { maxLossPerTradePct: 0.05 });
+  assert.equal(ok, false);
+});


### PR DESCRIPTION
## Summary
- extend risk engine with drawdown and loss management options
- track weekly and monthly losses and equity peak
- enforce cooloff after losing trade and per-trade loss limit
- test new risk engine features

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876907dff5c8325aaa8f01340df3142