### PR TITLE
Fix handling of invalid candle data

### DIFF
--- a/kite.js
+++ b/kite.js
@@ -1356,7 +1356,14 @@ export async function getHigherTimeframeData(symbol, timeframe = "15minute") {
 
 export function getSupportResistanceLevels(symbol) {
   const token = symbolTokenMap[symbol];
-  const candles = candleHistory[token] || [];
+  const candles = (candleHistory[token] || []).filter(
+    (c) =>
+      c &&
+      typeof c.high === "number" &&
+      !isNaN(c.high) &&
+      typeof c.low === "number" &&
+      !isNaN(c.low)
+  );
   if (!candles.length) return { support: null, resistance: null };
   const lows = candles.map((c) => c.low);
   const highs = candles.map((c) => c.high);

--- a/scanner.js
+++ b/scanner.js
@@ -90,10 +90,14 @@ export async function analyzeCandles(
     const validCandles = candles.filter(
       (c) =>
         c &&
-        c.open !== undefined &&
-        c.high !== undefined &&
-        c.low !== undefined &&
-        c.close !== undefined
+        typeof c.open === "number" &&
+        !isNaN(c.open) &&
+        typeof c.high === "number" &&
+        !isNaN(c.high) &&
+        typeof c.low === "number" &&
+        !isNaN(c.low) &&
+        typeof c.close === "number" &&
+        !isNaN(c.close)
     );
     if (validCandles.length < 5) return null;
     const features = computeFeatures(validCandles);


### PR DESCRIPTION
## Summary
- sanitize candle arrays in `analyzeCandles`
- ignore corrupt candles when calculating support/resistance levels

## Testing
- `npm test --silent` *(fails to connect to MongoDB but unit tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_6877294426288325b0237c9bd3c527f3