### PR TITLE
Add volatility and slippage risk filters

### DIFF
--- a/riskEngine.js
+++ b/riskEngine.js
@@ -6,6 +6,7 @@ import {
   validateATRStopLoss,
   validateSupportResistance,
   validateVolumeSpike,
+  validateVolatilitySlippage,
 } from './riskValidator.js';
 
 function getWeekNumber(d = new Date()) {
@@ -229,6 +230,25 @@ export function isSignalValid(signal, ctx = {}) {
     typeof ctx.avgVolume === 'number' &&
     typeof (signal.liquidity ?? ctx.volume) === 'number' &&
     (signal.liquidity ?? ctx.volume) < ctx.avgVolume * ctx.minVolumeRatio
+  )
+    return false;
+
+  if (
+    !validateVolatilitySlippage({
+      atr: signal.atr,
+      minATR: ctx.minVolatility,
+      maxATR: ctx.maxVolatility,
+      dailyRangePct: ctx.dailyRangePct,
+      maxDailySpikePct: ctx.rangeSpikeThreshold,
+      wickPct: ctx.wickPct,
+      volume: signal.liquidity ?? ctx.volume,
+      avgVolume: ctx.avgVolume,
+      consolidationRatio: ctx.consolidationVolumeRatio,
+      slippage: ctx.slippage,
+      maxSlippage: ctx.maxSlippage,
+      spread: signal.spread,
+      maxSpreadPct: ctx.maxSpreadPct,
+    })
   )
     return false;
 

--- a/riskValidator.js
+++ b/riskValidator.js
@@ -98,6 +98,55 @@ export function validateVolumeSpike({ volume, avgVolume, minSpike = 1.5 }) {
   return volume >= avgVolume * minSpike;
 }
 
+// Additional volatility and slippage checks
+export function validateVolatilitySlippage({
+  atr,
+  minATR,
+  maxATR,
+  dailyRangePct,
+  maxDailySpikePct,
+  wickPct,
+  volume,
+  avgVolume,
+  consolidationRatio = 0.3,
+  slippage,
+  maxSlippage,
+  spread,
+  maxSpreadPct,
+}) {
+  if (typeof minATR === 'number' && typeof atr === 'number' && atr < minATR)
+    return false;
+  if (typeof maxATR === 'number' && typeof atr === 'number' && atr > maxATR)
+    return false;
+  if (
+    typeof maxDailySpikePct === 'number' &&
+    typeof dailyRangePct === 'number' &&
+    dailyRangePct > maxDailySpikePct
+  )
+    return false;
+  if (typeof wickPct === 'number' && wickPct > 0.6) return false;
+  if (
+    typeof volume === 'number' &&
+    typeof avgVolume === 'number' &&
+    typeof consolidationRatio === 'number' &&
+    volume < avgVolume * consolidationRatio
+  )
+    return false;
+  if (
+    typeof slippage === 'number' &&
+    typeof maxSlippage === 'number' &&
+    slippage > maxSlippage
+  )
+    return false;
+  if (
+    typeof spread === 'number' &&
+    typeof maxSpreadPct === 'number' &&
+    spread > maxSpreadPct
+  )
+    return false;
+  return true;
+}
+
 export function checkMarketConditions({
   atr,
   avgAtr,

--- a/scanner.js
+++ b/scanner.js
@@ -49,6 +49,10 @@ const FILTERS = {
   maxSpread: MODE === "strict" ? 1.5 : 2.0,
   minLiquidity: MODE === "strict" ? 500 : 300,
   maxATR: MODE === "strict" ? 3.5 : 5.0,
+  rangeSpike: MODE === "strict" ? 10 : 15,
+  consolidationRatio: MODE === "strict" ? 0.5 : 0.3,
+  maxSlippage: MODE === "strict" ? 0.02 : 0.05,
+  maxSpreadPct: MODE === "strict" ? 0.3 : 0.5,
 };
 
 function logError(context, err) {
@@ -133,6 +137,21 @@ export async function analyzeCandles(
       volatilityClass,
     } = features;
     const last = validCandles.at(-1);
+    let dailyRangePct = 0;
+    if (Array.isArray(dailyHistory) && dailyHistory.length) {
+      const d = dailyHistory[dailyHistory.length - 1];
+      const ref = d.close ?? d.open ?? 1;
+      dailyRangePct = ref ? ((d.high - d.low) / ref) * 100 : 0;
+    }
+
+    let wickPct = 0;
+    if (last) {
+      const body = Math.abs(last.close - last.open) || 1;
+      const upper = last.high - Math.max(last.close, last.open);
+      const lower = Math.min(last.close, last.open) - last.low;
+      const wick = Math.max(upper, lower);
+      wickPct = wick / body;
+    }
     const expiryMinutes = calculateExpiryMinutes({ atr: atrValue, rvol });
     const expiresAt = new Date(
       Date.now() + expiryMinutes * 60 * 1000
@@ -207,6 +226,15 @@ export async function analyzeCandles(
       marketRegime: marketContext.regime,
       minATR: FILTERS.atrThreshold,
       maxATR: FILTERS.maxATR,
+      minVolatility: FILTERS.atrThreshold,
+      maxVolatility: FILTERS.maxATR,
+      dailyRangePct,
+      rangeSpikeThreshold: FILTERS.rangeSpike,
+      wickPct,
+      consolidationVolumeRatio: FILTERS.consolidationRatio,
+      slippage,
+      maxSlippage: FILTERS.maxSlippage,
+      maxSpreadPct: FILTERS.maxSpreadPct,
       minRR: RISK_REWARD_RATIO,
       minLiquidity: FILTERS.minLiquidity,
       minVolumeRatio: 0.5,

--- a/tests/newValidators.test.js
+++ b/tests/newValidators.test.js
@@ -8,6 +8,7 @@ const {
   validateATRStopLoss,
   validateSupportResistance,
   validateVolumeSpike,
+  validateVolatilitySlippage,
 } = await import('../riskValidator.js');
 
 auditMock.restore();
@@ -37,4 +38,35 @@ test('validateSupportResistance respects levels', () => {
 test('validateVolumeSpike requires spike over average', () => {
   assert.equal(validateVolumeSpike({ volume: 150, avgVolume: 100 }), true);
   assert.equal(validateVolumeSpike({ volume: 120, avgVolume: 100, minSpike: 1.3 }), false);
+});
+
+test('validateVolatilitySlippage enforces rules', () => {
+  assert.equal(
+    validateVolatilitySlippage({ atr: 0.5, minATR: 1 }),
+    false
+  );
+  assert.equal(
+    validateVolatilitySlippage({ atr: 2.5, maxATR: 2 }),
+    false
+  );
+  assert.equal(
+    validateVolatilitySlippage({ dailyRangePct: 20, maxDailySpikePct: 10 }),
+    false
+  );
+  assert.equal(
+    validateVolatilitySlippage({ spread: 0.4, maxSpreadPct: 0.3 }),
+    false
+  );
+  assert.equal(
+    validateVolatilitySlippage({ slippage: 0.05, maxSlippage: 0.02 }),
+    false
+  );
+  assert.equal(
+    validateVolatilitySlippage({ volume: 50, avgVolume: 200, consolidationRatio: 0.3 }),
+    false
+  );
+  assert.equal(
+    validateVolatilitySlippage({ atr: 1.5, minATR: 1, maxATR: 2, spread: 0.2, maxSpreadPct: 0.3 }),
+    true
+  );
 });

--- a/tests/riskEngine.test.js
+++ b/tests/riskEngine.test.js
@@ -209,3 +209,23 @@ test('isSignalValid enforces maxLossPerTradePct', () => {
   const ok = isSignalValid(sig, { maxLossPerTradePct: 0.05 });
   assert.equal(ok, false);
 });
+
+test('isSignalValid blocks excessive slippage and spread', () => {
+  resetRiskState();
+  const sig = {
+    stock: 'HHH',
+    pattern: 'trend',
+    direction: 'Long',
+    entry: 100,
+    stopLoss: 98,
+    target2: 104,
+    atr: 1,
+    spread: 0.5,
+  };
+  const ok = isSignalValid(sig, {
+    maxSpreadPct: 0.3,
+    slippage: 0.05,
+    maxSlippage: 0.02,
+  });
+  assert.equal(ok, false);
+});


### PR DESCRIPTION
## Summary
- extend risk validation with volatility and slippage checks
- apply new validation inside risk engine
- compute volatility metrics in scanner and pass to risk engine
- include config for new risk limits
- expand test suites for new validators and risk engine behaviour

## Testing
- `npm test` *(fails: analyzeCandles returns a signal for valid data, cannot connect to MongoDB, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68769f62ee708325a63e56a212e13ba3