### PR TITLE
Add new statistical risk checks

### DIFF
--- a/feedbackEngine.js
+++ b/feedbackEngine.js
@@ -1,4 +1,5 @@
 import db from './db.js';
+import { recordStrategyResult } from './confidence.js';
 
 // Track strategy weights and historical performance
 const weights = new Map();
@@ -47,6 +48,13 @@ export async function recordSignalOutcome(signal = {}, result = 0) {
   stat.trades += 1;
   if (result > 0) stat.wins += 1;
   stats.set(strategy, stat);
+
+  // keep short-term accuracy per symbol
+  recordStrategyResult(
+    signal.stock || signal.symbol || 'GEN',
+    strategy,
+    result > 0
+  );
 
   updateStrategyWeight(strategy, result > 0 ? 0.1 : -0.1);
 }

--- a/tests/confidence.test.js
+++ b/tests/confidence.test.js
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { computeConfidenceScore } from '../confidence.js';
+import { computeConfidenceScore, recordStrategyResult, getRecentAccuracy } from '../confidence.js';
 
 test('computeConfidenceScore blends factors', () => {
   const score = computeConfidenceScore({
@@ -96,4 +96,12 @@ test('evaluateTrendConfidence low on weak volume', async () => {
   );
   assert.equal(res.confidence, 'Low');
   kiteMock.restore();
+});
+
+test('getRecentAccuracy computes recent win rate', () => {
+  recordStrategyResult('AAA', 'trend', true);
+  recordStrategyResult('AAA', 'trend', false);
+  recordStrategyResult('AAA', 'trend', true);
+  const acc = getRecentAccuracy('AAA', 'trend');
+  assert.ok(acc > 0 && acc <= 1);
 });

--- a/tests/riskEngine.test.js
+++ b/tests/riskEngine.test.js
@@ -454,3 +454,67 @@ test('isSignalValid throttles in high volatility', () => {
   const ok = isSignalValid(sig, { volatility: 5, highVolatilityThresh: 4, throttleMs: 60000 });
   assert.equal(ok, false);
 });
+
+test('isSignalValid enforces backtest win rate threshold', () => {
+  resetRiskState();
+  const sig = {
+    stock: 'AAA',
+    pattern: 'trend',
+    direction: 'Long',
+    entry: 100,
+    stopLoss: 98,
+    target2: 104,
+    atr: 1,
+    spread: 0.1,
+  };
+  const ok = isSignalValid(sig, { backtestWinRate: 0.4, minBacktestWinRate: 0.5 });
+  assert.equal(ok, false);
+});
+
+test('isSignalValid enforces ML confidence threshold', () => {
+  resetRiskState();
+  const sig = {
+    stock: 'AAA',
+    pattern: 'trend',
+    direction: 'Long',
+    entry: 100,
+    stopLoss: 98,
+    target2: 104,
+    atr: 1,
+    spread: 0.1,
+  };
+  const ok = isSignalValid(sig, { mlConfidence: 0.4, minMlConfidence: 0.6 });
+  assert.equal(ok, false);
+});
+
+test('isSignalValid enforces recent accuracy threshold', () => {
+  resetRiskState();
+  const sig = {
+    stock: 'AAA',
+    pattern: 'trend',
+    direction: 'Long',
+    entry: 100,
+    stopLoss: 98,
+    target2: 104,
+    atr: 1,
+    spread: 0.1,
+  };
+  const ok = isSignalValid(sig, { recentAccuracy: 0.4, minRecentAccuracy: 0.5 });
+  assert.equal(ok, false);
+});
+
+test('isSignalValid enforces entry std dev and z-score', () => {
+  resetRiskState();
+  const sig = {
+    stock: 'AAA',
+    pattern: 'trend',
+    direction: 'Long',
+    entry: 100,
+    stopLoss: 98,
+    target2: 104,
+    atr: 1,
+    spread: 0.1,
+  };
+  const ok = isSignalValid(sig, { entryStdDev: 2, maxEntryStdDev: 1.5, zScore: 0.2, minZScoreAbs: 0.5 });
+  assert.equal(ok, false);
+});


### PR DESCRIPTION
## Summary
- track recent strategy results in `confidence`
- propagate result recording in `feedbackEngine`
- compute entry price stddev/z-score and check risk constraints
- add context checks for ML confidence, backtest win rate, and recent accuracy
- test new accuracy helpers and risk conditions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a8863fff88325b04a408f4b187b9d