### PR TITLE
Implement advanced signal ranking metrics

### DIFF
--- a/signalRanker.js
+++ b/signalRanker.js
@@ -1,4 +1,8 @@
-import { getStrategyHitRate, timeOfDayScore } from './confidence.js';
+import {
+  getStrategyHitRate,
+  getRecentAccuracy,
+  timeOfDayScore,
+} from './confidence.js';
 import { marketContext } from './smartStrategySelector.js';
 
 function confidenceLevelScore(level) {
@@ -58,6 +62,132 @@ function rrPotentialScore(signal) {
   return Math.min(reward / risk / 3, 1); // saturate at RR=3
 }
 
+function signalAgeScore(signal) {
+  const ts = new Date(signal.time || signal.generatedAt || Date.now()).getTime();
+  const age = Date.now() - ts;
+  if (age < 60_000) return 1;
+  if (age < 5 * 60_000) return 0.7;
+  if (age < 10 * 60_000) return 0.5;
+  return 0.3;
+}
+
+function candleStrengthScore(signal) {
+  const { open, close, high, low } = signal;
+  if ([open, close, high, low].some((v) => typeof v !== 'number')) return 0.5;
+  const body = Math.abs(close - open);
+  const range = high - low || 1;
+  const bodyPct = body / range;
+  const wickRatio = body / (range - body || 1);
+  return Math.min(bodyPct * 0.7 + Math.min(wickRatio, 1) * 0.3, 1);
+}
+
+function volumeSpikeScore(signal) {
+  if (typeof signal.rvol === 'number') {
+    return Math.min(signal.rvol / 2, 1);
+  }
+  if (signal.volume && signal.avgVolume) {
+    return Math.min(signal.volume / signal.avgVolume / 2, 1);
+  }
+  return 0.5;
+}
+
+function multiTimeframeScore(signal) {
+  return Math.min((signal.multiTFConfirmations || 0) / 3, 1);
+}
+
+function trendAlignmentScore(signal) {
+  if (typeof signal.trend === 'string') {
+    return signal.trend.toLowerCase() === signal.direction?.toLowerCase()
+      ? 1
+      : 0.4;
+  }
+  if (signal.ema200 && signal.entry) {
+    if (
+      (signal.direction === 'Long' && signal.entry > signal.ema200) ||
+      (signal.direction === 'Short' && signal.entry < signal.ema200)
+    )
+      return 1;
+    return 0.4;
+  }
+  return 0.5;
+}
+
+function backtestAccuracyScore(signal) {
+  const recent = getRecentAccuracy(signal.stock || '', signal.pattern || '');
+  return Math.max(0, Math.min(recent, 1));
+}
+
+function volatilityEdgeScore(signal) {
+  if (typeof signal.atr !== 'number') return 0.5;
+  if (signal.atr >= 1 && signal.atr <= 2) return 1;
+  if (signal.atr >= 0.5 && signal.atr <= 3) return 0.7;
+  return 0.4;
+}
+
+function priceActionScore(signal) {
+  if (typeof signal.priceActionScore === 'number') return signal.priceActionScore;
+  return 0.5;
+}
+
+function entryEfficiencyScore(signal) {
+  if (
+    typeof signal.entry === 'number' &&
+    typeof signal.support === 'number' &&
+    typeof signal.resistance === 'number'
+  ) {
+    const dist = Math.min(
+      Math.abs(signal.entry - signal.support),
+      Math.abs(signal.resistance - signal.entry)
+    );
+    const range = Math.abs(signal.resistance - signal.support) || 1;
+    return Math.min(1 - dist / range, 1);
+  }
+  return 0.5;
+}
+
+function orderBlockProximityScore(signal) {
+  if (typeof signal.orderBlockDist !== 'number') return 0.5;
+  return Math.max(0, Math.min(1 - signal.orderBlockDist, 1));
+}
+
+function indexCorrelationScore(signal) {
+  if (typeof signal.indexCorrelation === 'number') {
+    return Math.max(0, Math.min(Math.abs(signal.indexCorrelation), 1));
+  }
+  return 0.5;
+}
+
+function sectorConfirmationScore(signal) {
+  if (typeof signal.sectorScore === 'number') return signal.sectorScore;
+  return 0.5;
+}
+
+function gapQualityScore(signal) {
+  if (typeof signal.gapQuality === 'number') return signal.gapQuality;
+  return 0.5;
+}
+
+function retestSuccessScore(signal) {
+  if (typeof signal.retestSuccessRate === 'number')
+    return Math.max(0, Math.min(signal.retestSuccessRate, 1));
+  return 0.5;
+}
+
+function slippageRiskScore(signal) {
+  if (typeof signal.slippage !== 'number') return 0.5;
+  return Math.max(0, Math.min(1 - signal.slippage, 1));
+}
+
+function newsSentimentScore(signal) {
+  if (typeof signal.newsSentiment === 'number')
+    return Math.max(0, Math.min((signal.newsSentiment + 1) / 2, 1));
+  return 0.5;
+}
+
+function confluenceCountScore(signal) {
+  return Math.min((signal.confluenceCount || 0) / 5, 1);
+}
+
 function scoreSignal(signal = {}) {
   const confScore = confidenceLevelScore(signal.confidence);
   const todScore = timeOfDayScore(signal.time ? new Date(signal.time) : new Date());
@@ -69,15 +199,49 @@ function scoreSignal(signal = {}) {
   const patternScore = patternStrengthScore(signal.patternStrength);
   const regimeScore = marketRegimeScore(signal);
   const volScore = volatilityFitScore(signal.atr);
+  const ageScore = signalAgeScore(signal);
+  const candleScore = candleStrengthScore(signal);
+  const volSpike = volumeSpikeScore(signal);
+  const mtfScore = multiTimeframeScore(signal);
+  const trendScore = trendAlignmentScore(signal);
+  const backtestScore = backtestAccuracyScore(signal);
+  const volEdge = volatilityEdgeScore(signal);
+  const paScore = priceActionScore(signal);
+  const entryEff = entryEfficiencyScore(signal);
+  const obScore = orderBlockProximityScore(signal);
+  const idxScore = indexCorrelationScore(signal);
+  const sectorScoreVal = sectorConfirmationScore(signal);
+  const gapScore = gapQualityScore(signal);
+  const retestScore = retestSuccessScore(signal);
+  const slipScore = slippageRiskScore(signal);
+  const newsScore = newsSentimentScore(signal);
+  const confCount = confluenceCountScore(signal);
 
   return (
-    confScore * 0.25 +
-    hitRate * 0.25 +
-    rrScore * 0.15 +
-    patternScore * 0.1 +
-    regimeScore * 0.15 +
-    volScore * 0.1 +
-    todScore * 0.1
+    confScore * 0.2 +
+    hitRate * 0.05 +
+    rrScore * 0.1 +
+    ageScore * 0.05 +
+    candleScore * 0.05 +
+    volSpike * 0.05 +
+    patternScore * 0.05 +
+    mtfScore * 0.05 +
+    trendScore * 0.05 +
+    backtestScore * 0.05 +
+    volEdge * 0.05 +
+    paScore * 0.05 +
+    entryEff * 0.05 +
+    obScore * 0.02 +
+    idxScore * 0.02 +
+    sectorScoreVal * 0.02 +
+    gapScore * 0.02 +
+    retestScore * 0.02 +
+    slipScore * 0.03 +
+    newsScore * 0.02 +
+    confCount * 0.05 +
+    regimeScore * 0.05 +
+    volScore * 0.03 +
+    todScore * 0.05
   );
 }
 


### PR DESCRIPTION
## Summary
- expand `signalRanker` with many additional scoring metrics
- integrate backtest accuracy and new factors into final ranking score

## Testing
- `npm test --silent` *(fails: Mongo connection ENOTFOUND)*

------
https://chatgpt.com/codex/tasks/task_e_687b3a9ab5d88325a27b0e72280aefcc