### PR TITLE
Implement advanced signal filtering

### DIFF
--- a/tradeLifecycle.js
+++ b/tradeLifecycle.js
@@ -85,6 +85,8 @@ export async function executeSignal(signal, opts = {}) {
       preventOverlap: true,
       openSymbols: Array.from(openPositions.keys()),
       openPositionsMap: openPositions,
+      addToWatchlist: true,
+      blockWatchlist: true,
     })
   )
     return null;


### PR DESCRIPTION
## Summary
- extend `riskEngine` with watchlist, strategy failure tracking, time bucket, and additional checks
- incorporate momentum and volatility constraints in scanner
- ensure trade lifecycle adds new signals to watchlist

## Testing
- `npm test` *(fails: Mongo connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_687b530fa6bc8325a2c5f6ea16bf9463