### PR TITLE
Fix util mocks for tests

### DIFF
--- a/scanner.js
+++ b/scanner.js
@@ -41,12 +41,6 @@ initAccountBalance().then((bal) => {
 const riskPerTradePercentage = 0.01;
 
 // 🚦 Risk control state
-let riskState = {
-  dailyLoss: 0,
-  consecutiveLosses: 0,
-  lastResetDay: new Date().getDate(),
-};
-
 // ⚙️ Scanner mode toggle
 const MODE = "relaxed"; // Options: "strict" | "relaxed"
 const FILTERS = {

--- a/tests/analyzeCandles.test.js
+++ b/tests/analyzeCandles.test.js
@@ -24,6 +24,7 @@ const featureMock = test.mock.module('../featureEngine.js', {
     calculateRSI: () => 60,
     calculateSupertrend: () => ({ signal: 'Buy' }),
     calculateVWAP: () => 100,
+    calculateAnchoredVWAP: () => 100,
     getATR: () => 2.5,
     computeFeatures: () => ({
       ema9: 105,
@@ -60,6 +61,13 @@ const utilMock = test.mock.module('../util.js', {
     toISTDate: (d = new Date()) => '2024-01-01',
     convertTickTimestampsToIST: (t) => t,
     getMAForSymbol: () => 100,
+    isStrongPriceAction: () => true,
+    getWickNoise: () => 0,
+    isAtrStable: () => true,
+    isAwayFromConsolidation: () => true,
+    calculateStdDev: () => 1,
+    calculateZScore: () => 0,
+    patternConfluenceAcrossTimeframes: () => true,
     DEFAULT_MARGIN_PERCENT: 0.2
   }
 });

--- a/tests/newPatterns.test.js
+++ b/tests/newPatterns.test.js
@@ -8,6 +8,7 @@ const featureMock = test.mock.module('../featureEngine.js', {
     calculateRSI: () => 50,
     calculateSupertrend: () => ({ signal: 'Sell' }),
     calculateVWAP: () => 0,
+    calculateAnchoredVWAP: () => 0,
     getATR: () => 1,
     computeFeatures: () => ({ ema9: 0, ema21: 0, ema200: 0, rsi: 50 })
   }
@@ -16,6 +17,13 @@ const utilMock = test.mock.module('../util.js', {
   namedExports: {
     confirmRetest: () => true,
     detectAllPatterns: () => [],
+    calculateStdDev: () => 1,
+    calculateZScore: () => 0,
+    isStrongPriceAction: () => true,
+    getWickNoise: () => 0,
+    isAtrStable: () => true,
+    isAwayFromConsolidation: () => true,
+    patternConfluenceAcrossTimeframes: () => true,
     DEFAULT_MARGIN_PERCENT: 0.2,
   }
 });


### PR DESCRIPTION
## Summary
- avoid redeclaring `riskState` in `scanner.js`
- extend test mocks with more util exports so unit tests start

## Testing
- `npm test` *(fails: isSignalValid respects configured RR threshold)*

------
https://chatgpt.com/codex/tasks/task_e_687b70ea89a483259f209e051da52b0f