### PR TITLE
Add database persistence for signals

### DIFF
--- a/db.js
+++ b/db.js
@@ -8,6 +8,7 @@ let client;
 let database;
 
 async function ensureIndexes(db) {
+  if (typeof db.collection !== 'function') return;
   await db.collection("historical_session_data").createIndex({ token: 1, date: 1 });
   await db.collection("signals").createIndex(
     { generatedAt: 1 },
@@ -16,6 +17,10 @@ async function ensureIndexes(db) {
   await db.collection("tick_data").createIndex(
     { timestamp: 1 },
     { expireAfterSeconds: 60 * 60 * 24 }
+  );
+  await db.collection("active_signals").createIndex(
+    { expiresAt: 1 },
+    { expireAfterSeconds: 0 }
   );
 }
 

--- a/kite.js
+++ b/kite.js
@@ -869,7 +869,7 @@ async function emitUnifiedSignal(signal, source, io) {
   io.emit("tradeSignal", signal);
   logTrade(signal);
   sendSignal(signal);
-  addSignal(signal);
+  await addSignal(signal);
   logSignalCreated(signal, {
     vix: marketContext.vix,
     regime: marketContext.regime,

--- a/signalManager.js
+++ b/signalManager.js
@@ -1,8 +1,9 @@
 export const activeSignals = new Map(); // symbol -> Map<signalId, info>
 import { sendNotification } from './telegram.js';
 import { logSignalExpired, logSignalMutation } from './auditLogger.js';
+import db from './db.js';
 
-export function addSignal(signal) {
+export async function addSignal(signal) {
   const symbol = signal.stock || signal.symbol;
   const direction = signal.direction || (signal.side === 'buy' ? 'Long' : 'Short');
   const confidence = signal.confidence || signal.confidenceScore || 0;
@@ -28,6 +29,15 @@ export function addSignal(signal) {
         timestamp: new Date().toISOString(),
       });
       sendNotification && sendNotification(`Signal for ${symbol} cancelled due to conflict`);
+      try {
+        await db.collection('active_signals').updateOne(
+          { signalId: info.signal.signalId || info.signal.algoSignal?.signalId },
+          { $set: { status: 'cancelled', updatedAt: new Date() } },
+          { upsert: true }
+        );
+      } catch (err) {
+        console.error('DB update failed', err.message);
+      }
     }
   }
 
@@ -38,10 +48,31 @@ export function addSignal(signal) {
     confidence,
     expiresAt,
   });
+
+  try {
+    await db.collection('active_signals').updateOne(
+      { signalId },
+      {
+        $set: {
+          signal,
+          symbol,
+          direction,
+          confidence,
+          expiresAt: new Date(expiresAt),
+          status: 'active',
+          updatedAt: new Date(),
+        },
+        $setOnInsert: { createdAt: new Date() },
+      },
+      { upsert: true }
+    );
+  } catch (err) {
+    console.error('DB insert failed', err.message);
+  }
   return true;
 }
 
-export function checkExpiries(now = Date.now()) {
+export async function checkExpiries(now = Date.now()) {
   for (const [symbol, sigMap] of activeSignals.entries()) {
     for (const [id, info] of sigMap.entries()) {
       if (info.status === 'active' && info.expiresAt && now > info.expiresAt) {
@@ -57,6 +88,14 @@ export function checkExpiries(now = Date.now()) {
             category: 'naturalExpiry',
           }
         );
+        try {
+          await db.collection('active_signals').updateOne(
+            { signalId: info.signal.signalId || info.signal.algoSignal?.signalId },
+            { $set: { status: 'expired', updatedAt: new Date(now) } }
+          );
+        } catch (err) {
+          console.error('DB expiry update failed', err.message);
+        }
       }
     }
   }

--- a/tests/signalLifecycle.test.js
+++ b/tests/signalLifecycle.test.js
@@ -5,7 +5,7 @@ const auditMock = test.mock.module('../auditLogger.js', {
   namedExports: { logSignalExpired: () => {}, logSignalMutation: () => {} }
 });
 const dbMock = test.mock.module('../db.js', {
-  defaultExport: {},
+  defaultExport: { collection: () => ({ updateOne: async () => {} }) },
   namedExports: { connectDB: async () => ({}) }
 });
 
@@ -26,9 +26,9 @@ const signal = {
   signalId: 'sig1',
 };
 
-addSignal(signal);
+await addSignal(signal);
 
-checkExpiries(now + 2000);
+await checkExpiries(now + 2000);
 
 test('signal expires after expiry time', () => {
   const sigMap = activeSignals.get('TEST');


### PR DESCRIPTION
## Summary
- persist active signals to MongoDB when added
- update DB when signals expire or are cancelled
- index `active_signals` collection in `db.js`
- await `addSignal` in `kite.js`
- adjust signal lifecycle test for async behavior

## Testing
- `npm test` *(fails: Mongo connection errors)*

------
https://chatgpt.com/codex/tasks/task_e_687c89166c048325a66331a614529114