### PR TITLE
Persist new signals

### DIFF
--- a/signalManager.js
+++ b/signalManager.js
@@ -66,6 +66,15 @@ export async function addSignal(signal) {
       },
       { upsert: true }
     );
+    await db.collection('signals').insertOne({
+      ...signal,
+      signalId,
+      symbol,
+      direction,
+      confidence,
+      expiresAt: new Date(expiresAt),
+      generatedAt: signal.generatedAt ? new Date(signal.generatedAt) : new Date(),
+    });
   } catch (err) {
     console.error('DB insert failed', err.message);
   }


### PR DESCRIPTION
## Summary
- store generated signals in the `signals` collection

## Testing
- `npm test` *(fails: `--experimental-test-module-mocks` not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_687c93d7aa488325b68a96f6bc84c46b