### PR TITLE
Improve error logging

### DIFF
--- a/dataEngine.js
+++ b/dataEngine.js
@@ -1,5 +1,6 @@
 import { kc, initSession, tickBuffer, candleHistory, symbolTokenMap } from './kite.js';
 import db from './db.js';
+import { logError } from './logger.js';
 
 export function getLiveTicks(token) {
   return tickBuffer[token] || [];
@@ -33,7 +34,7 @@ export async function getFundamentals(symbol) {
   try {
     return await db.collection('fundamentals').findOne({ symbol });
   } catch (err) {
-    console.error('Fundamental fetch error', err.message);
+    logError('Fundamental fetch error', err);
     return null;
   }
 }
@@ -42,7 +43,7 @@ export async function getNews(symbol) {
   try {
     return await db.collection('news').find({ symbol }).toArray();
   } catch (err) {
-    console.error('News fetch error', err.message);
+    logError('News fetch error', err);
     return [];
   }
 }

--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ import {
 } from "./smartStrategySelector.js";
 import { selectTopSignal } from "./signalRanker.js";
 import { logTrade } from "./tradeLogger.js";
+import { logError } from "./logger.js";
 
 const app = express();
 const server = http.createServer(app);
@@ -94,7 +95,7 @@ app.post("/addStockSymbol", async (req, res) => {
     const updated = await db.collection("stock_symbols").findOne({});
     res.json({ status: "success", symbols: updated?.symbols || [] });
   } catch (err) {
-    console.error("❌ Error:", err.message);
+    logError("update symbols", err);
     res.status(500).json({ error: "Failed to update symbols" });
   }
 });
@@ -105,7 +106,7 @@ app.get("/stockSymbols", async (req, res) => {
     const stockSymbols = await db.collection("stock_symbols").findOne({});
     res.json(stockSymbols || { symbols: [] });
   } catch (err) {
-    console.error("❌ Error fetching stock symbols:", err);
+    logError("fetching stock symbols", err);
     res.status(500).json({ error: "Failed to fetch stock symbols" });
   }
 });
@@ -124,7 +125,7 @@ app.delete("/stockSymbols/:symbol", async (req, res) => {
       deletedSymbol: symbol.includes(":") ? symbol : `NSE:${symbol}`,
     });
   } catch (err) {
-    console.error("❌ Error deleting stock symbol:", err);
+    logError("delete stock symbol", err);
     res.status(500).json({ error: "Failed to delete stock symbol" });
   }
 });
@@ -149,7 +150,7 @@ app.delete("/reset", async (req, res) => {
     resetInMemoryData();
     res.json({ status: "success", message: "Collections reset successfully" });
   } catch (err) {
-    console.error("❌ Error resetting collections:", err);
+    logError("reset collections", err);
     res.status(500).json({ error: "Failed to reset collections" });
   }
 });
@@ -165,7 +166,7 @@ app.get("/signals", async (req, res) => {
     // res.json(signals);
     res.json({ status: "success", signals: signals });
   } catch (err) {
-    console.error("❌ Error fetching signals:", err);
+    logError("fetching signals", err);
     res.status(500).json({ error: "Failed to fetch signals" });
   }
 });
@@ -193,7 +194,7 @@ app.post("/fetch-intraday-data", async (req, res) => {
     await fetchHistoricalIntradayData(interval, days);
     res.json({ status: "success" });
   } catch (err) {
-    console.error("❌ Intraday fetch error:", err.message);
+    logError("intraday fetch", err);
     res.status(500).json({ error: "Failed to fetch intraday data" });
   }
 });

--- a/logger.js
+++ b/logger.js
@@ -1,0 +1,12 @@
+import { sendNotification } from './telegram.js';
+
+export function logError(context, err) {
+  console.error(`[${context}]`, err);
+  try {
+    if (sendNotification) {
+      sendNotification(`[ERROR] ${context}: ${err.message || err}`);
+    }
+  } catch (e) {
+    console.error('[logError] Failed to send notification', e);
+  }
+}

--- a/signalManager.js
+++ b/signalManager.js
@@ -2,6 +2,7 @@ export const activeSignals = new Map(); // symbol -> Map<signalId, info>
 import { sendNotification } from './telegram.js';
 import { logSignalExpired, logSignalMutation } from './auditLogger.js';
 import db from './db.js';
+import { logError } from './logger.js';
 
 export async function addSignal(signal) {
   const symbol = signal.stock || signal.symbol;
@@ -36,7 +37,7 @@ export async function addSignal(signal) {
           { upsert: true }
         );
       } catch (err) {
-        console.error('DB update failed', err.message);
+        logError('DB update failed', err);
       }
     }
   }
@@ -76,7 +77,7 @@ export async function addSignal(signal) {
       generatedAt: signal.generatedAt ? new Date(signal.generatedAt) : new Date(),
     });
   } catch (err) {
-    console.error('DB insert failed', err.message);
+    logError('DB insert failed', err);
   }
   return true;
 }
@@ -103,7 +104,7 @@ export async function checkExpiries(now = Date.now()) {
             { $set: { status: 'expired', updatedAt: new Date(now) } }
           );
         } catch (err) {
-          console.error('DB expiry update failed', err.message);
+          logError('DB expiry update failed', err);
         }
       }
     }


### PR DESCRIPTION
## Summary
- centralize error logging in logger.js
- log DB errors with stack info via logError
- use logError in dataEngine, signalManager, and HTTP routes

## Testing
- `npm test` *(fails: detectAllPatterns identifies Swing Failure Pattern (Bearish); detectAllPatterns identifies Wolfe Wave (Bullish); detectAllPatterns identifies Bull Trap After Gap Up; detectAllPatterns identifies Bear Trap After Gap Down; isSignalValid respects configured RR threshold)*

------
https://chatgpt.com/codex/tasks/task_e_687c98a673308325b8e4003f99b14449