### PR TITLE
Refresh account balance before executing signals

### DIFF
--- a/scanner.js
+++ b/scanner.js
@@ -383,7 +383,16 @@ export async function rankAndExecute(signals = []) {
   const { selectTopSignal } = await import("./signalRanker.js");
   const top = selectTopSignal(signals);
   if (top) {
-    await sendToExecution(top);
+    accountBalance = await initAccountBalance();
+    if (accountBalance > 0) {
+      await sendToExecution(top);
+    } else {
+      console.log(
+        `[SKIP] Insufficient balance. Signal for ${
+          top.stock || top.symbol
+        } not executed`
+      );
+    }
   }
   return top;
 }


### PR DESCRIPTION
## Summary
- update `rankAndExecute` to fetch latest balance before sending a signal to execution

## Testing
- `npm test` *(fails: Mongo connection ENOTFOUND)*

------
https://chatgpt.com/codex/tasks/task_e_687cb3d4253c83258a670c8fb516fe66