### PR TITLE
Add rejected signal logging

### DIFF
--- a/tests/analyzeCandles.test.js
+++ b/tests/analyzeCandles.test.js
@@ -2,6 +2,17 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 process.env.NODE_ENV = 'test';
 
+const auditMock = test.mock.module('../auditLogger.js', {
+  namedExports: {
+    logSignalRejected: () => {},
+    logSignalExpired: () => {},
+    logSignalMutation: () => {},
+    logSignalCreated: () => {},
+    logBacktestReference: () => {},
+    getLogs: () => ({})
+  }
+});
+
 const kiteMock = test.mock.module('../kite.js', {
   namedExports: {
     getHigherTimeframeData: async () => ({
@@ -106,5 +117,6 @@ test('analyzeCandles returns a signal for valid data', async () => {
   kiteMock.restore();
   featureMock.restore();
   utilMock.restore();
+  auditMock.restore();
   dbMock.restore();
 });


### PR DESCRIPTION
## Summary
- log rejected trade signals for better analysis
- mock audit logger in analyzeCandles tests

## Testing
- `npm test --silent` *(fails: isSignalValid respects configured RR threshold)*

------
https://chatgpt.com/codex/tasks/task_e_687cb6cb1e548325a970abf1e3f7b356