### PR TITLE
Implement order websocket tracking

### DIFF
--- a/tests/analyzeCandles.test.js
+++ b/tests/analyzeCandles.test.js
@@ -25,7 +25,10 @@ const kiteMock = test.mock.module('../kite.js', {
     initSession: async () => 'token',
     kc: { getLTP: async (symbols) => ({ [symbols[0]]: { last_price: 100, instrument_token: 123 } }) },
     tickBuffer: {},
-    getSupportResistanceLevels: () => ({ support: 90, resistance: 110 })
+    getSupportResistanceLevels: () => ({ support: 90, resistance: 110 }),
+    getMA: () => null,
+    onOrderUpdate: () => {},
+    orderEvents: { on: () => {} }
   }
 });
 

--- a/tests/canPlaceTrade.test.js
+++ b/tests/canPlaceTrade.test.js
@@ -2,6 +2,17 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 process.env.NODE_ENV = 'test';
 
+const kiteMock = test.mock.module('../kite.js', {
+  namedExports: {
+    onOrderUpdate: () => {},
+    orderEvents: { on: () => {} },
+    kc: {},
+    symbolTokenMap: {},
+    historicalCache: {},
+    initSession: async () => {}
+  }
+});
+
 const orderMod = await import('../orderExecution.js');
 
 const marginMock = test.mock.method(orderMod, 'getAccountMargin', async () => ({
@@ -16,6 +27,7 @@ const res = await orderMod.canPlaceTrade({ symbol: 'AAA', direction: 'Long' });
 
 getMarginMock.mock.restore();
 marginMock.mock.restore();
+kiteMock.restore();
 
 test('canPlaceTrade computes quantity using margin', () => {
   assert.equal(res.canPlace, true);

--- a/tests/confidence.test.js
+++ b/tests/confidence.test.js
@@ -39,7 +39,10 @@ test('evaluateTrendConfidence basic high', async () => {
       getHigherTimeframeData: async () => ({
         ema50: 90,
         supertrend: { signal: 'Buy' }
-      })
+      }),
+      getMA: () => null,
+      onOrderUpdate: () => {},
+      orderEvents: { on: () => {} }
     }
   });
   const { evaluateTrendConfidence } = await import('../confidence.js');
@@ -79,7 +82,10 @@ test('evaluateTrendConfidence low on weak volume', async () => {
       getHigherTimeframeData: async () => ({
         ema50: 90,
         supertrend: { signal: 'Buy' }
-      })
+      }),
+      getMA: () => null,
+      onOrderUpdate: () => {},
+      orderEvents: { on: () => {} }
     }
   });
   const { evaluateTrendConfidence } = await import('../confidence.js');

--- a/tests/confirmRetest.test.js
+++ b/tests/confirmRetest.test.js
@@ -1,7 +1,13 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-const kiteMock = test.mock.module('../kite.js', { namedExports: { getMA: () => null } });
+const kiteMock = test.mock.module('../kite.js', {
+  namedExports: {
+    getMA: () => null,
+    onOrderUpdate: () => {},
+    orderEvents: { on: () => {} }
+  }
+});
 const dbMock = test.mock.module('../db.js', {
   defaultExport: {},
   namedExports: { connectDB: async () => ({}) }

--- a/tests/newPatterns.test.js
+++ b/tests/newPatterns.test.js
@@ -1,7 +1,13 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-const kiteMock = test.mock.module('../kite.js', { namedExports: { getMA: () => null } });
+const kiteMock = test.mock.module('../kite.js', {
+  namedExports: {
+    getMA: () => null,
+    onOrderUpdate: () => {},
+    orderEvents: { on: () => {} }
+  }
+});
 const featureMock = test.mock.module('../featureEngine.js', {
   namedExports: {
     calculateEMA: () => 0,

--- a/tests/orderUpdate.test.js
+++ b/tests/orderUpdate.test.js
@@ -1,0 +1,31 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'events';
+process.env.NODE_ENV = 'test';
+
+const emitter = new EventEmitter();
+const kiteMock = test.mock.module('../kite.js', {
+  namedExports: {
+    orderEvents: emitter,
+    onOrderUpdate: (cb) => emitter.on('update', cb),
+    kc: {},
+    symbolTokenMap: {},
+    historicalCache: {},
+    initSession: async () => {}
+  }
+});
+
+const { openTrades } = await import('../orderExecution.js');
+
+let received;
+emitter.on('update', (u) => { received = u; });
+
+openTrades.set('e1', { entryId: 'e1', slId: 's1', targetId: 't1', status: 'OPEN' });
+emitter.emit('update', { order_id: 'e1', status: 'COMPLETE' });
+
+test('order update listener updates trades map', () => {
+  assert.deepEqual(received, { order_id: 'e1', status: 'COMPLETE' });
+  assert.equal(openTrades.has('e1'), false);
+});
+
+kiteMock.restore();

--- a/tests/patternDetection.test.js
+++ b/tests/patternDetection.test.js
@@ -1,7 +1,13 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-const kiteMock = test.mock.module('../kite.js', { namedExports: { getMA: () => null } });
+const kiteMock = test.mock.module('../kite.js', {
+  namedExports: {
+    getMA: () => null,
+    onOrderUpdate: () => {},
+    orderEvents: { on: () => {} }
+  }
+});
 const dbMock = test.mock.module('../db.js', {
   defaultExport: {},
   namedExports: { connectDB: async () => ({}) }

--- a/tests/positionSizing.test.js
+++ b/tests/positionSizing.test.js
@@ -6,7 +6,13 @@ const dbMock = test.mock.module('../db.js', {
   defaultExport: {},
   namedExports: { connectDB: async () => ({}) }
 });
-const kiteMock = test.mock.module('../kite.js', { namedExports: { getMA: () => null } });
+const kiteMock = test.mock.module('../kite.js', {
+  namedExports: {
+    getMA: () => null,
+    onOrderUpdate: () => {},
+    orderEvents: { on: () => {} }
+  }
+});
 
 const {
   calculatePositionSize,

--- a/tests/removeStockSymbolRoute.test.js
+++ b/tests/removeStockSymbolRoute.test.js
@@ -7,7 +7,9 @@ const kiteMock = test.mock.module('../kite.js', {
   namedExports: {
     removeStockSymbol: async (sym) => {
       called = sym;
-    }
+    },
+    onOrderUpdate: () => {},
+    orderEvents: { on: () => {} }
   }
 });
 

--- a/tests/riskEngine.test.js
+++ b/tests/riskEngine.test.js
@@ -11,7 +11,13 @@ const auditMock = test.mock.module('../auditLogger.js', {
     getLogs: () => ({}),
   }
 });
-const kiteMock = test.mock.module('../kite.js', { namedExports: { getMA: () => null } });
+const kiteMock = test.mock.module('../kite.js', {
+  namedExports: {
+    getMA: () => null,
+    onOrderUpdate: () => {},
+    orderEvents: { on: () => {} }
+  }
+});
 const dbMock = test.mock.module('../db.js', {
   defaultExport: {
     collection: () => ({

--- a/tests/riskValidator.test.js
+++ b/tests/riskValidator.test.js
@@ -11,7 +11,13 @@ const auditMock = test.mock.module('../auditLogger.js', {
     getLogs: () => ({}),
   }
 });
-const kiteMock = test.mock.module('../kite.js', { namedExports: { getMA: () => null } });
+const kiteMock = test.mock.module('../kite.js', {
+  namedExports: {
+    getMA: () => null,
+    onOrderUpdate: () => {},
+    orderEvents: { on: () => {} }
+  }
+});
 const dbMock = test.mock.module('../db.js', {
   defaultExport: {
     collection: () => ({


### PR DESCRIPTION
## Summary
- add EventEmitter for Kite order updates
- expose order update functions in `kite.js`
- update `orderExecution` to handle live order events
- adjust tests with new mocks
- test order update event handling

## Testing
- `npm test` *(fails: ERR_TEST_FAILURE)*

------
https://chatgpt.com/codex/tasks/task_e_687d21575c6883259f6c09bd3ef13f0b