### PR TITLE
Couple exit monitor to order fills

### DIFF
--- a/exitManager.js
+++ b/exitManager.js
@@ -81,12 +81,15 @@ export function shouldExit(signal, price, timeHeldMs) {
  * @param {number} [handlers.intervalMs]
  * @returns {NodeJS.Timeout}
  */
+let monitorHandle = null;
+
 export function startExitMonitor(
   activeTrades,
   { exitTrade, logTradeExit, intervalMs = 60 * 1000 } = {}
 ) {
   if (!activeTrades) return null;
-  return setInterval(() => {
+  if (monitorHandle) clearInterval(monitorHandle);
+  monitorHandle = setInterval(() => {
     const trades = activeTrades instanceof Map ? activeTrades.values() : activeTrades;
     for (const openTrade of trades) {
       const exitSignal = checkExitConditions(openTrade);
@@ -96,4 +99,12 @@ export function startExitMonitor(
       }
     }
   }, intervalMs);
+  return monitorHandle;
+}
+
+export function stopExitMonitor() {
+  if (monitorHandle) {
+    clearInterval(monitorHandle);
+    monitorHandle = null;
+  }
 }

--- a/kite.js
+++ b/kite.js
@@ -16,7 +16,11 @@ import {
   preventReEntry,
   resolveSignalConflicts,
   notifyExposureEvents,
+  openPositions,
+  recordExit,
 } from "./portfolioContext.js";
+import { startExitMonitor } from "./exitManager.js";
+import { logTrade as recordTrade } from "./tradeLogger.js";
 dotenv.config();
 
 import db from "./db.js"; // 🧠 Import database module for future use
@@ -200,6 +204,12 @@ let riskState = {
   maxConsecutiveLosses: 3,
 };
 let gapPercent = {};
+let exitMonitorStarted = false;
+
+function handleExit(trade, reason) {
+  recordExit(trade.symbol);
+  recordTrade({ symbol: trade.symbol, reason, event: "exit" });
+}
 
 // 🔐 Initialize Kite session
 async function initSession() {
@@ -390,6 +400,13 @@ async function startLiveFeed(io) {
   ticker.on("order_update", (update) => {
     orderUpdateMap.set(update.order_id, update);
     orderEvents.emit("update", update);
+    if (!exitMonitorStarted && update.status === "COMPLETE") {
+      startExitMonitor(openPositions, {
+        exitTrade: handleExit,
+        logTradeExit: handleExit,
+      });
+      exitMonitorStarted = true;
+    }
   });
 
   ticker.on("error", (err) => {

--- a/scanner.js
+++ b/scanner.js
@@ -18,7 +18,6 @@ import { evaluateAllStrategies } from "./strategyEngine.js";
 import { evaluateStrategies } from "./strategies.js";
 import { RISK_REWARD_RATIO, calculatePositionSize } from "./positionSizing.js";
 import { isSignalValid, riskState } from "./riskEngine.js";
-import { startExitMonitor } from "./exitManager.js";
 import { openPositions, recordExit } from "./portfolioContext.js";
 import { logTrade } from "./tradeLogger.js";
 import {
@@ -380,17 +379,7 @@ export function getSignalHistory() {
   return signalHistory;
 }
 
-function handleExit(trade, reason) {
-  recordExit(trade.symbol);
-  logTrade({ symbol: trade.symbol, reason, event: "exit" });
-}
-
-if (process.env.NODE_ENV !== "test") {
-  startExitMonitor(openPositions, {
-    exitTrade: handleExit,
-    logTradeExit: handleExit,
-  });
-}
+// Exit monitoring now starts after order fills via kite.js
 
 // Rank signals and send top one to execution
 export async function rankAndExecute(signals = []) {


### PR DESCRIPTION
## Summary
- trigger exit monitoring once an order fill is confirmed
- avoid multiple exit monitors and allow stopping
- decouple scanner from exit monitor startup

## Testing
- `npm test` *(fails: testCodeFailure in pattern detection suite)*

------
https://chatgpt.com/codex/tasks/task_e_687da71e89c48325a43a3909066a2b92