### PR TITLE
Add margin check before execution

### DIFF
--- a/tests/analyzeCandles.test.js
+++ b/tests/analyzeCandles.test.js
@@ -82,7 +82,8 @@ const utilMock = test.mock.module('../util.js', {
     calculateStdDev: () => 1,
     calculateZScore: () => 0,
     patternConfluenceAcrossTimeframes: () => true,
-    DEFAULT_MARGIN_PERCENT: 0.2
+    DEFAULT_MARGIN_PERCENT: 0.2,
+    calculateRequiredMargin: () => 100
   }
 });
 

--- a/tests/newPatterns.test.js
+++ b/tests/newPatterns.test.js
@@ -31,6 +31,7 @@ const utilMock = test.mock.module('../util.js', {
     isAwayFromConsolidation: () => true,
     patternConfluenceAcrossTimeframes: () => true,
     DEFAULT_MARGIN_PERCENT: 0.2,
+    calculateRequiredMargin: () => 100,
   }
 });
 const dbMock = test.mock.module('../db.js', { defaultExport: {}, namedExports: { connectDB: async () => ({}) } });


### PR DESCRIPTION
## Summary
- verify margin before sending to execution
- expose margin function to scanner tests

## Testing
- `npm test` *(fails: Mongo connection errors)*

------
https://chatgpt.com/codex/tasks/task_e_687e8437ea4c832585ffc4b9f24616d3