### PR TITLE
Fix reset cleanup for kite session

### DIFF
--- a/kite.js
+++ b/kite.js
@@ -1440,6 +1440,13 @@ function resetInMemoryData() {
   historicalCache = {};
   historicalSessionData = {};
   warmupDone = false;
+  if (ticker) {
+    try {
+      ticker.disconnect();
+    } catch {}
+    ticker = null;
+  }
+  kc.setAccessToken("");
 }
 
 export {


### PR DESCRIPTION
## Summary
- ensure `resetInMemoryData` disconnects the ticker
- clear the KiteConnect access token when resetting

## Testing
- `npm test` *(fails: Mongo connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_687f19989908832589c307d42e6b346b