### PR TITLE
Implement order update listener and logging

### DIFF
--- a/tradeLogger.js
+++ b/tradeLogger.js
@@ -9,3 +9,9 @@ export async function logTrade(trade) {
 export async function recordPnL(symbol, pnl) {
   await logTrade({ symbol, pnl });
 }
+
+export async function logOrderUpdate(update) {
+  if (!db?.collection) return;
+  const col = db.collection('order_updates');
+  await col.insertOne({ ...update, timestamp: new Date() });
+}


### PR DESCRIPTION
## Summary
- log all order updates in `tradeLogger`
- emit order updates to exit manager from `kite.js`
- hook up ticker order update event handler

## Testing
- `npm test` *(fails: Mongo connection timeout)*

------
https://chatgpt.com/codex/tasks/task_e_687f993da4388325b815fe61d06a8963