### PR TITLE
Clarify exit monitor trigger

### DIFF
--- a/kite.js
+++ b/kite.js
@@ -215,6 +215,7 @@ function handleOrderUpdate(update) {
   orderUpdateMap.set(update.order_id, update);
   orderEvents.emit("update", update);
   logOrderUpdate(update);
+  // Start monitoring exits only after the first order is actually filled
   if (!exitMonitorStarted && update.status === "COMPLETE") {
     startExitMonitor(openPositions, {
       exitTrade: handleExit,

--- a/scanner.js
+++ b/scanner.js
@@ -380,7 +380,7 @@ export function getSignalHistory() {
   return signalHistory;
 }
 
-// Exit monitoring now starts after order fills via kite.js
+// Exit monitoring is triggered from kite.js once an order update reports COMPLETE
 
 // Rank signals and send top one to execution
 export async function rankAndExecute(signals = []) {


### PR DESCRIPTION
## Summary
- explain in comments that exit monitor starts after first order fill

## Testing
- `npm test` *(fails to finish due to hanging processes)*

------
https://chatgpt.com/codex/tasks/task_e_687fa5c480648325afd53d756bac7943