### PR TITLE
Add order tag for traceability

### DIFF
--- a/orderExecution.js
+++ b/orderExecution.js
@@ -46,11 +46,9 @@ export async function sendOrder(variety = "regular", order, opts = {}) {
       const { meta, ...orderParams } = order || {};
       if (meta) {
         const { strategy, signalId, confidence } = meta;
-        const tagParts = [];
-        if (strategy) tagParts.push(strategy.substring(0, 4));
-        if (signalId) tagParts.push(signalId.slice(-4));
-        if (confidence !== undefined) tagParts.push(String(confidence));
-        const tag = tagParts.join("-").slice(0, 20);
+        const tag = [signalId, strategy, confidence]
+          .filter((v) => v !== undefined && v !== null)
+          .join('_');
         orderParams.tag = orderParams.tag || tag;
       }
 

--- a/tests/sendOrderTag.test.js
+++ b/tests/sendOrderTag.test.js
@@ -1,0 +1,43 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+process.env.NODE_ENV = 'test';
+
+const kiteMock = test.mock.module('../kite.js', {
+  namedExports: {
+    kc: { placeOrder: async (params) => params },
+    symbolTokenMap: {},
+    historicalCache: {},
+    initSession: async () => {},
+    onOrderUpdate: () => {},
+    getMA: () => {},
+  }
+});
+
+const dbMock = test.mock.module('../db.js', {
+  defaultExport: { collection: () => ({}) },
+  namedExports: { connectDB: async () => ({ collection: () => ({}) }) }
+});
+
+const auditMock = test.mock.module('../auditLogger.js', {
+  namedExports: { logSignalRejected: () => {}, logSignalCreated: () => {} }
+});
+
+const { sendOrder } = await import('../orderExecution.js');
+
+const res = await sendOrder('regular', {
+  exchange: 'NSE',
+  tradingsymbol: 'AAA',
+  transaction_type: 'BUY',
+  quantity: 1,
+  order_type: 'MARKET',
+  product: 'MIS',
+  meta: { signalId: 'sig1', strategy: 'stratA', confidence: 'High' }
+});
+
+kiteMock.restore();
+dbMock.restore();
+auditMock.restore();
+
+test('sendOrder adds tag from metadata', () => {
+  assert.equal(res.tag, 'sig1_stratA_High');
+});


### PR DESCRIPTION
## Summary
- set `order.tag` in `sendOrder` using signal metadata
- cover new functionality with `sendOrderTag` test

## Testing
- `npm test` *(fails: Mongo connection errors)*

------
https://chatgpt.com/codex/tasks/task_e_687fac2556148325bbb5052a4951fa95