### PR TITLE
Implement dynamic quality weights

### DIFF
--- a/scanner.js
+++ b/scanner.js
@@ -323,15 +323,18 @@ export async function analyzeCandles(
       strategyConfidence: base.confidence,
       support,
       resistance,
-      finalScore: signalQualityScore({
-        atr: atrValue,
-        rvol,
-        strongPriceAction,
-        cleanBody: wickPct < 0.3,
-        rrRatio: riskReward,
-        atrStable,
-        awayFromConsolidation: consolidationOk,
-      }),
+      finalScore: signalQualityScore(
+        {
+          atr: atrValue,
+          rvol,
+          strongPriceAction,
+          cleanBody: wickPct < 0.3,
+          rrRatio: riskReward,
+          atrStable,
+          awayFromConsolidation: consolidationOk,
+        },
+        { symbol, strategy: base.strategy }
+      ),
       expiresAt,
       riskAmount: accountBalance * riskPerTradePercentage,
       accountBalance,

--- a/tests/confidence.test.js
+++ b/tests/confidence.test.js
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { computeConfidenceScore, recordStrategyResult, getRecentAccuracy, applyPenaltyConditions } from '../confidence.js';
+import { computeConfidenceScore, recordStrategyResult, getRecentAccuracy, applyPenaltyConditions, signalQualityScore } from '../confidence.js';
 
 test('computeConfidenceScore blends factors', () => {
   const score = computeConfidenceScore({
@@ -120,4 +120,19 @@ test('getRecentAccuracy computes recent win rate', () => {
   recordStrategyResult('AAA', 'trend', true);
   const acc = getRecentAccuracy('AAA', 'trend');
   assert.ok(acc > 0 && acc <= 1);
+});
+
+test('signalQualityScore scales with history', () => {
+  const base = signalQualityScore(
+    { atr: 1, rvol: 1, strongPriceAction: false },
+    { symbol: 'BBB', strategy: 'trend' }
+  );
+  for (let i = 0; i < 5; i++) {
+    recordStrategyResult('BBB', 'trend', true);
+  }
+  const improved = signalQualityScore(
+    { atr: 1, rvol: 1, strongPriceAction: false },
+    { symbol: 'BBB', strategy: 'trend' }
+  );
+  assert.ok(improved > base);
 });


### PR DESCRIPTION
## Summary
- add in-memory learning weights
- scale signal quality with recent accuracy
- use signal and strategy info when scoring
- test quality score learning

## Testing
- `npm test` *(fails: querySrv ENOTFOUND cluster0.53r8xqg.mongodb.net)*

------
https://chatgpt.com/codex/tasks/task_e_687fcbc3be9c8325926187adb3613335