### PR TITLE
Use dynamic account balance for exposure limits

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,6 @@ import { logError } from "./logger.js";
 const app = express();
 const server = http.createServer(app);
 
-const TOTAL_CAPITAL = Number(process.env.TOTAL_CAPITAL) || 100000;
 
 const allowedOrigins = [
   "https://scanner-app-fe.onrender.com",

--- a/kite.js
+++ b/kite.js
@@ -21,6 +21,7 @@ import {
 } from "./portfolioContext.js";
 import { startExitMonitor } from "./exitManager.js";
 import { logTrade as recordTrade, logOrderUpdate } from "./tradeLogger.js";
+import { getAccountBalance, initAccountBalance } from "./account.js";
 dotenv.config();
 
 import db from "./db.js"; // 🧠 Import database module for future use
@@ -31,7 +32,7 @@ const __dirname = path.dirname(__filename);
 const apiKey = process.env.KITE_API_KEY;
 const apiSecret = process.env.KITE_API_SECRET;
 const kc = new KiteConnect({ api_key: apiKey });
-const TOTAL_CAPITAL = Number(process.env.TOTAL_CAPITAL) || 100000;
+await initAccountBalance();
 
 // Order update event emitter and storage
 export const orderEvents = new EventEmitter();
@@ -893,7 +894,7 @@ async function emitUnifiedSignal(signal, source, io) {
       symbol,
       tradeValue,
       sector: signal.sector || "GEN",
-      totalCapital: TOTAL_CAPITAL,
+      totalCapital: getAccountBalance(),
     }) &&
     resolveSignalConflicts({
       symbol,

--- a/scanner.js
+++ b/scanner.js
@@ -45,8 +45,7 @@ initAccountBalance().then((bal) => {
 });
 const riskPerTradePercentage = 0.01;
 
-// Portfolio exposure controls
-const TOTAL_CAPITAL = Number(process.env.TOTAL_CAPITAL) || 100000;
+// Portfolio exposure controls - use dynamic account balance as capital
 const MAX_OPEN_TRADES = Number(process.env.MAX_OPEN_TRADES) || 10;
 const SECTOR_CAPS = {
   // default sector caps; override via env if needed
@@ -415,7 +414,7 @@ export async function rankAndExecute(signals = []) {
         symbol: top.stock || top.symbol,
         tradeValue,
         sector,
-        totalCapital: TOTAL_CAPITAL,
+        totalCapital: accountBalance,
         sectorCaps: SECTOR_CAPS,
       });
     if (!exposureOk) {


### PR DESCRIPTION
## Summary
- remove unused TOTAL_CAPITAL constant from index.js
- rely on account balance for exposure checks in scanner and kite modules
- initialize account balance when kite module loads

## Testing
- `npm test` *(fails: Mongo connection error)*

------
https://chatgpt.com/codex/tasks/task_e_68804f8c15bc832590e610cefb2ab19c