### PR TITLE
Add detailed exit logging

### DIFF
--- a/kite.js
+++ b/kite.js
@@ -17,9 +17,9 @@ import {
   resolveSignalConflicts,
   notifyExposureEvents,
   openPositions,
-  recordExit,
+  recordExit as markExit,
 } from "./portfolioContext.js";
-import { startExitMonitor } from "./exitManager.js";
+import { startExitMonitor, recordExit as logExit } from "./exitManager.js";
 import { logTrade as recordTrade, logOrderUpdate } from "./tradeLogger.js";
 import { getAccountBalance, initAccountBalance } from "./account.js";
 dotenv.config();
@@ -208,8 +208,8 @@ let gapPercent = {};
 let exitMonitorStarted = false;
 
 function handleExit(trade, reason) {
-  recordExit(trade.symbol);
-  recordTrade({ symbol: trade.symbol, reason, event: "exit" });
+  markExit(trade.symbol);
+  logExit(trade, reason, trade.lastPrice);
 }
 
 function handleOrderUpdate(update) {

--- a/tradeLogger.js
+++ b/tradeLogger.js
@@ -1,9 +1,12 @@
 import db from './db.js';
 
-export async function logTrade(trade) {
+export async function logTrade(trade, exitReason = undefined, exitPrice = undefined) {
   if (!db?.collection) return;
   const col = db.collection('trade_logs');
-  await col.insertOne({ ...trade, timestamp: new Date() });
+  const logEntry = { ...trade, timestamp: new Date() };
+  if (exitReason) logEntry.exitReason = exitReason;
+  if (typeof exitPrice === 'number') logEntry.exitPrice = exitPrice;
+  await col.insertOne(logEntry);
 }
 
 export async function recordPnL(symbol, pnl) {


### PR DESCRIPTION
## Summary
- allow logTrade to store exit details
- support P&L logging in exitManager
- update Kite exit handling to use new logger

## Testing
- `npm test` *(fails: not ok 4 - tests/canPlaceTrade.test.js, not ok 5 - tests/confidence.test.js, not ok 9 - tests/exitManager.test.js, ...)*

------
https://chatgpt.com/codex/tasks/task_e_6880575385288325939c137d4e06a225