### PR TITLE
Fix circular import around account margin

### DIFF
--- a/account.js
+++ b/account.js
@@ -1,7 +1,20 @@
 // account.js
-import { getAccountMargin } from "./orderExecution.js";
+// Provides utilities for fetching and caching account related data
+import { kc, initSession } from "./kite.js";
 
 let accountBalance = 0;
+
+// Fetch margin available across equity using the shared Kite instance
+export async function getAccountMargin() {
+  try {
+    await initSession();
+    const response = await kc.getMargins("equity");
+    return response;
+  } catch (err) {
+    console.error(`[ACCOUNT] Error fetching account margin`, err?.message || err);
+    return null;
+  }
+}
 
 export function getAccountBalance() {
   return accountBalance;

--- a/orderExecution.js
+++ b/orderExecution.js
@@ -8,6 +8,7 @@ import {
   initSession,
   onOrderUpdate,
 } from "./kite.js"; // reuse shared Kite instance and session handler
+import { getAccountMargin } from "./account.js";
 import { calculateDynamicStopLoss } from "./dynamicRiskModel.js";
 
 // Store order id -> metadata mapping for traceability
@@ -171,22 +172,6 @@ export async function getHoldings() {
   } catch (err) {
     logError("Error fetching holdings", err);
     return [];
-  }
-}
-
-// Get margin available across equity
-export async function getAccountMargin() {
-  try {
-    await initSession();
-    const response = await kc.getMargins("equity");
-    console.log("Access token:", kc.access_token);
-
-    // console the account margin details
-    console.log("Account Margin:", response);
-    return response;
-  } catch (err) {
-    logError("Error fetching account margin", err);
-    return null;
   }
 }
 

--- a/tests/canPlaceTrade.test.js
+++ b/tests/canPlaceTrade.test.js
@@ -14,8 +14,9 @@ const kiteMock = test.mock.module('../kite.js', {
 });
 
 const orderMod = await import('../orderExecution.js');
+const accountMod = await import('../account.js');
 
-const marginMock = test.mock.method(orderMod, 'getAccountMargin', async () => ({
+const marginMock = test.mock.method(accountMod, 'getAccountMargin', async () => ({
   equity: { available: { cash: 10000 } },
 }));
 


### PR DESCRIPTION
## Summary
- avoid importing `orderExecution` from `account`
- implement margin lookup directly in `account.js`
- update `orderExecution` to use the new helper
- adapt `canPlaceTrade` test

## Testing
- `npm test` *(fails: Mongo connection blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68807dd2f8548325a4e6a3041aaa833f