### PR TITLE
Implement daily order reconciliation audit

### DIFF
--- a/auditEngine.js
+++ b/auditEngine.js
@@ -1,0 +1,64 @@
+import db from './db.js';
+import cron from 'node-cron';
+import { logError } from './logger.js';
+
+/**
+ * Compare executed_signals and trade_logs for a given date.
+ * Returns lists of missing and unexpected trades.
+ * @param {Date} [date]
+ */
+export async function reconcileOrders(date = new Date()) {
+  const start = new Date(date);
+  start.setHours(0, 0, 0, 0);
+  const end = new Date(start);
+  end.setDate(start.getDate() + 1);
+
+  try {
+    const [executed, trades] = await Promise.all([
+      db
+        .collection('executed_signals')
+        .find({ timestamp: { $gte: start, $lt: end } })
+        .toArray(),
+      db
+        .collection('trade_logs')
+        .find({ timestamp: { $gte: start, $lt: end } })
+        .toArray(),
+    ]);
+
+    const executedIds = new Set(
+      executed.map((e) => e.signalId).filter(Boolean)
+    );
+    const tradeIds = new Set(trades.map((t) => t.signalId).filter(Boolean));
+
+    const missing = [...executedIds].filter((id) => !tradeIds.has(id));
+    const unexpected = [...tradeIds].filter((id) => !executedIds.has(id));
+
+    return { missing, unexpected, executedCount: executed.length, tradeCount: trades.length };
+  } catch (err) {
+    logError('dailyAudit', err);
+    return { missing: [], unexpected: [], executedCount: 0, tradeCount: 0 };
+  }
+}
+
+export function startAuditSchedule() {
+  if (process.env.NODE_ENV === 'test') return;
+  cron.schedule(
+    '10 16 * * 1-5',
+    async () => {
+      const res = await reconcileOrders();
+      console.log('[AUDIT] Executed:', res.executedCount, 'Trades:', res.tradeCount);
+      if (res.missing.length)
+        console.log('[AUDIT] Missing trades for signals:', res.missing.join(', '));
+      if (res.unexpected.length)
+        console.log(
+          '[AUDIT] Unexpected trades with no executed signal:',
+          res.unexpected.join(', ')
+        );
+      if (!res.missing.length && !res.unexpected.length)
+        console.log('[AUDIT] \u2705 All trades reconciled.');
+    },
+    { timezone: 'Asia/Kolkata' }
+  );
+}
+
+startAuditSchedule();

--- a/index.js
+++ b/index.js
@@ -43,6 +43,7 @@ import {
 import { selectTopSignal } from "./signalRanker.js";
 import { logTrade } from "./tradeLogger.js";
 import { logError } from "./logger.js";
+import "./auditEngine.js";
 
 const app = express();
 const server = http.createServer(app);

--- a/tests/auditEngine.test.js
+++ b/tests/auditEngine.test.js
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+process.env.NODE_ENV = 'test';
+
+const executed = [{ signalId: 'A', timestamp: new Date() }];
+const trades = [
+  { signalId: 'A', timestamp: new Date() },
+  { signalId: 'B', timestamp: new Date() },
+];
+
+const dbMock = test.mock.module('../db.js', {
+  defaultExport: {
+    collection: (name) => ({
+      find: () => ({
+        toArray: async () => (name === 'executed_signals' ? executed : trades),
+      }),
+    }),
+  },
+  namedExports: { connectDB: async () => ({}) },
+});
+
+const loggerMock = test.mock.module('../logger.js', {
+  namedExports: { logError: () => {} },
+});
+
+const { reconcileOrders } = await import('../auditEngine.js');
+
+dbMock.restore();
+loggerMock.restore();
+
+const result = await reconcileOrders(new Date());
+
+test('reconcileOrders detects discrepancies', () => {
+  assert.deepEqual(result.missing, []);
+  assert.deepEqual(result.unexpected, ['B']);
+});


### PR DESCRIPTION
## Summary
- create `auditEngine.js` to compare `executed_signals` with `trade_logs`
- schedule audit to run every weekday at 4:10 PM IST
- auto-start audit in `index.js`
- cover reconciliation logic with a new unit test

## Testing
- `npm test` *(fails: not ok 5 - tests/canPlaceTrade.test.js, not ok 6 - tests/confidence.test.js, not ok 10 - tests/exitManager.test.js, not ok 12 - tests/feedbackEngine.test.js, not ok 17 - Breakout above Resistance detected)*

------
https://chatgpt.com/codex/tasks/task_e_6880f4a3b4788325ad5a553ac2f67e24