### PR TITLE
feat: add scoring rubric and dedup strategy results

### DIFF
--- a/signalRanker.js
+++ b/signalRanker.js
@@ -248,7 +248,10 @@ function scoreSignal(signal = {}) {
 export function rankSignals(signals = [], topN = 1) {
   if (!Array.isArray(signals) || signals.length === 0) return [];
   const ranked = signals
-    .map((s) => ({ ...s, score: scoreSignal(s) }))
+    .map((s) => ({
+      ...s,
+      score: typeof s.score === 'number' ? s.score : scoreSignal(s),
+    }))
     .sort((a, b) => b.score - a.score);
   return ranked.slice(0, topN);
 }


### PR DESCRIPTION
## Summary
- compute per-detector score with trend, volume, risk and context penalties in strategies
- normalize results with new scoring and merge duplicate strategy outputs by name
- respect existing score when ranking signals

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad2c55d3e88325bfb75283f77b951d