### PR TITLE
fix: return access token string from initSession

### DIFF
--- a/kite.js
+++ b/kite.js
@@ -276,16 +276,17 @@ async function initSession() {
       return null;
     }
 
-    kc.setAccessToken(session.access_token);
+    const accessToken = String(session.access_token);
+    kc.setAccessToken(accessToken);
 
     // 🔍 Optional: Check if token is still valid by calling a protected endpoint
     try {
       await kc.getProfile(); // Throws if token is expired
       console.log("✅ Access token is valid and set.");
-      return session;
+      return accessToken;
     } catch (err) {
       console.error("❌ Access token is expired or invalid.", err.message);
-      // RESET DATA BASE
+      kc.setAccessToken("");
       // await resetDatabase();
       return null;
     }


### PR DESCRIPTION
## Summary
- ensure `initSession` returns the access token string used by KiteTicker
- clear KiteConnect access token when invalid to avoid reuse

## Testing
- `npm test` *(fails: SyntaxError: The requested module './kite.js' does not provide an export named 'getMA'; Mongo connection failed: querySrv ENOTFOUND _mongodb._tcp.cluster0.53r8xqg.mongodb.net)*

------
https://chatgpt.com/codex/tasks/task_e_68af4c5b8c4c83259fc0db32df435ff4