### PR TITLE
fix: remove duplicate riskState export

### DIFF
--- a/riskEngine.js
+++ b/riskEngine.js
@@ -528,5 +528,3 @@ export function isSignalValid(signal, ctx = {}) {
   if (ctx.addToWatchlist) riskState.watchList.add(inst);
   return true;
 }
-
-export { riskState };


### PR DESCRIPTION
## Summary
- remove duplicate `riskState` export in riskEngine to avoid SyntaxError

## Testing
- `npm test` *(fails: querySrv ENOTFOUND `_mongodb._tcp.cluster0.53r8xqg.mongodb.net`; duplicate declaration `placeGTTOrder`)*

------
https://chatgpt.com/codex/tasks/task_e_68b64831502883258d5102633a7910ca