### PR TITLE
Avoid duplicate GTT helper name

### DIFF
--- a/orderExecution.js
+++ b/orderExecution.js
@@ -35,8 +35,12 @@ dotenv.config();
 
 // kc instance and session handled in kite.js
 
-// Place an order
-async function placeGTTOrder(orderParams, meta) {
+// Place a bracket-style GTT order with both stop loss and target legs.
+// Internal helper used by sendOrder when the caller provides stop-loss
+// and target values. Uses an OCO trigger so that either leg exits the
+// position. Not exported to avoid clashing with the generic GTT helper
+// defined later in this module.
+async function placeBracketGTTOrder(orderParams, meta) {
   const sl = orderParams.stopLoss ?? orderParams.sl;
   const target = orderParams.target ?? orderParams.squareoff;
   if (sl == null || target == null) return null;
@@ -94,7 +98,7 @@ export async function sendOrder(variety = "regular", order, opts = {}) {
       // parameters, convert to a two-leg GTT order. This helps lock in
       // both risk and reward in a single request.
       if (variety === "gtt" || (orderParams.stopLoss && orderParams.target)) {
-        const response = await placeGTTOrder(orderParams, meta);
+        const response = await placeBracketGTTOrder(orderParams, meta);
         if (response) return response;
       }
 


### PR DESCRIPTION
## Summary
- rename internal GTT helper to `placeBracketGTTOrder` and document its purpose
- update `sendOrder` to call the renamed helper

## Testing
- `npm test` *(fails: The requested module './kite.js' does not provide an export named 'getMA'; Mongo connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b64d1adda083258e43b79aa6657f5d