### PR TITLE
Stop telegram alerts for rejected signals

### DIFF
--- a/auditLogger.js
+++ b/auditLogger.js
@@ -93,6 +93,9 @@ export async function logSignalRejected(
     ['validationDetails']
   );
   try {
+    await db.createCollection('rejected_signals');
+  } catch {}
+  try {
     await db.collection('rejected_signals').insertOne({
       signalId,
       reasonCode,
@@ -100,8 +103,9 @@ export async function logSignalRejected(
       signal: signalData,
       timestamp: new Date(),
     });
-  } catch {}
-  sendCriticalAlerts('rejection', { signalId, reasonCode });
+  } catch (e) {
+    console.error('Failed to store rejected signal', e.message);
+  }
 }
 
 export async function logBacktestReference(params, results) {

--- a/kite.js
+++ b/kite.js
@@ -10,7 +10,7 @@ import { ObjectId } from "mongodb";
 import { sendSignal } from "./telegram.js";
 import { fetchAIData } from "./openAI.js";
 import { addSignal } from "./signalManager.js";
-import { logSignalCreated } from "./auditLogger.js";
+import { logSignalCreated, logSignalRejected } from "./auditLogger.js";
 import {
   checkExposureLimits,
   preventReEntry,
@@ -956,7 +956,12 @@ async function emitUnifiedSignal(signal, source, io) {
       strategy: signal.pattern,
     });
   if (!allowed) {
-    notifyExposureEvents(`Signal for ${symbol} rejected by portfolio rules`);
+    await logSignalRejected(
+      signal.signalId || signal.algoSignal?.signalId || `${symbol}-${Date.now()}`,
+      "portfolioRules",
+      { message: `Signal for ${symbol} rejected by portfolio rules` },
+      signal
+    );
     return;
   }
   console.log(`🚀 Emitting ${source} Signal:`, signal);


### PR DESCRIPTION
## Summary
- Log rejected signals to database collection `rejected_signals`
- Avoid sending Telegram notifications when signals fail portfolio checks

## Testing
- `npm test` *(fails: /workspace/scaneer-app-be/tests/confidence.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b675eda5f083258af0853c18eb742c