### PR TITLE
Relax VWAP participation filter to allow signals

### DIFF
--- a/scanner.js
+++ b/scanner.js
@@ -257,7 +257,7 @@ export async function analyzeCandles(
       minRR: RISK_REWARD_RATIO,
       minLiquidity: FILTERS.minLiquidity,
       minVolumeRatio: 0.5,
-      minVwapParticipation: 0.98,
+      minVwapParticipation: 0.9,
       maxIndexVolatility: 20,
       blockWatchlist: true,
       addToWatchlist: false,

--- a/tests/analyzeCandles.test.js
+++ b/tests/analyzeCandles.test.js
@@ -117,7 +117,8 @@ test('analyzeCandles returns a signal for valid data', async () => {
     5000,
     null
   );
-  assert.equal(signal, null);
+  assert.ok(signal);
+  assert.equal(typeof signal.pattern, 'string');
   kiteMock.restore();
   featureMock.restore();
   utilMock.restore();


### PR DESCRIPTION
## Summary
- Loosen VWAP participation requirement so legitimate signals are not filtered out.
- Add test ensuring scanner returns a signal with valid input.

## Testing
- `node --test --experimental-test-module-mocks tests/analyzeCandles.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b71c5e70e88325b3faef57114a8d75