### PR TITLE
Use database-backed historical data

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ import {
   startLiveFeed,
   updateInstrumentTokens,
   setTickInterval,
-  getAverageVolume,
   isMarketOpen,
   setStockSymbol,
   removeStockSymbol,

--- a/orderExecution.js
+++ b/orderExecution.js
@@ -4,9 +4,9 @@ const logError = (ctx, err) => console.error(`[${ctx}]`, err?.message || err);
 import {
   kc,
   symbolTokenMap,
-  historicalCache,
   initSession,
   onOrderUpdate,
+  getHistoricalData,
 } from "./kite.js"; // reuse shared Kite instance and session handler
 import { getAccountMargin } from "./account.js";
 import { calculateDynamicStopLoss } from "./dynamicRiskModel.js";
@@ -189,7 +189,7 @@ export async function getMarginForStock(order) {
     const response = await kc.orderMargins(order);
 
     const token = symbolTokenMap[order.tradingsymbol];
-    const hist = historicalCache[token] || [];
+    const hist = await getHistoricalData(token);
     const avgRange =
       hist.length > 1
         ? hist.slice(-20).reduce((a, b) => a + (b.high - b.low), 0) /

--- a/scanner.js
+++ b/scanner.js
@@ -12,7 +12,7 @@ import {
   isAwayFromConsolidation,
 } from "./util.js";
 
-import { getSupportResistanceLevels, historicalCache } from "./kite.js";
+import { getSupportResistanceLevels, getHistoricalData } from "./kite.js";
 import { candleHistory, symbolTokenMap } from "./dataEngine.js";
 import { evaluateAllStrategies } from "./strategyEngine.js";
 import { evaluateStrategies } from "./strategies.js";
@@ -119,7 +119,7 @@ export async function analyzeCandles(
     if (!features) return null;
 
     const token = symbolTokenMap[symbol];
-    const dailyHistory = historicalCache[token] || [];
+    const dailyHistory = await getHistoricalData(token);
     const sessionData = candleHistory[token] || validCandles;
 
     const context = {
@@ -302,11 +302,13 @@ export async function analyzeCandles(
       qty,
     };
 
+    const ma20Val = await getMAForSymbol(String(token), 20);
+    const ma50Val = await getMAForSymbol(String(token), 50);
     const contextForBuild = {
       symbol,
       instrumentToken: token,
-      ma20Val: getMAForSymbol(String(token), 20),
-      ma50Val: getMAForSymbol(String(token), 50),
+      ma20Val,
+      ma50Val,
       ema9,
       ema21,
       ema50,

--- a/tests/analyzeCandles.test.js
+++ b/tests/analyzeCandles.test.js
@@ -20,7 +20,7 @@ const kiteMock = test.mock.module('../kite.js', {
       supertrend: { signal: 'Buy' }
     }),
     candleHistory: {},
-    historicalCache: {},
+    getHistoricalData: async () => [],
     symbolTokenMap: {},
     initSession: async () => 'token',
     kc: { getLTP: async (symbols) => ({ [symbols[0]]: { last_price: 100, instrument_token: 123 } }) },

--- a/tests/canPlaceTrade.test.js
+++ b/tests/canPlaceTrade.test.js
@@ -8,8 +8,9 @@ const kiteMock = test.mock.module('../kite.js', {
     orderEvents: { on: () => {} },
     kc: {},
     symbolTokenMap: {},
-    historicalCache: {},
-    initSession: async () => {}
+    getHistoricalData: async () => [],
+    initSession: async () => {},
+    getMA: () => null
   }
 });
 

--- a/tests/confidence.test.js
+++ b/tests/confidence.test.js
@@ -1,7 +1,14 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+process.env.NODE_ENV = 'test';
 
-import { computeConfidenceScore, recordStrategyResult, getRecentAccuracy, applyPenaltyConditions, signalQualityScore } from '../confidence.js';
+const {
+  computeConfidenceScore,
+  recordStrategyResult,
+  getRecentAccuracy,
+  applyPenaltyConditions,
+  signalQualityScore,
+} = await import('../confidence.js');
 
 test('computeConfidenceScore blends factors', () => {
   const score = computeConfidenceScore({

--- a/tests/orderUpdate.test.js
+++ b/tests/orderUpdate.test.js
@@ -10,8 +10,9 @@ const kiteMock = test.mock.module('../kite.js', {
     onOrderUpdate: (cb) => emitter.on('update', cb),
     kc: {},
     symbolTokenMap: {},
-    historicalCache: {},
-    initSession: async () => {}
+    getHistoricalData: async () => [],
+    initSession: async () => {},
+    getMA: () => null
   }
 });
 

--- a/tests/sendOrderTag.test.js
+++ b/tests/sendOrderTag.test.js
@@ -6,7 +6,7 @@ const kiteMock = test.mock.module('../kite.js', {
   namedExports: {
     kc: { placeOrder: async (params) => params },
     symbolTokenMap: {},
-    historicalCache: {},
+    getHistoricalData: async () => [],
     initSession: async () => {},
     onOrderUpdate: () => {},
     getMA: () => {},

--- a/util.js
+++ b/util.js
@@ -138,8 +138,8 @@ export function calculateMA(prices, length) {
 // function reuses the last computed EMA value for that key to avoid
 // recalculating from the start of the array on every tick.
 
-export function getMAForSymbol(symbol, period) {
-  return getMA(symbol, period);
+export async function getMAForSymbol(symbol, period) {
+  return await getMA(symbol, period);
 }
 
 export function toISTISOString(date = new Date()) {


### PR DESCRIPTION
## Summary
- replace in-memory `historicalCache` with `getHistoricalData` that queries the `historical_data` collection
- compute indicators like MA, ATR, and average volume using data pulled from the database
- update scanner, order executor, utilities, and tests to use the new DB-backed data path

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b87d4ebe188325bb7572328e10c28d