### PR TITLE
Persist aligned tick data in MongoDB

### DIFF
--- a/db.js
+++ b/db.js
@@ -24,6 +24,10 @@ async function ensureIndexes(db) {
     { expiresAt: 1 },
     { expireAfterSeconds: 0 }
   );
+  // Ensure aligned tick storage exists for minute-level tick aggregation
+  await db
+    .collection("aligned_ticks")
+    .createIndex({ token: 1, minute: 1 }, { unique: true });
 }
 
 export const connectDB = async (attempt = 0) => {

--- a/index.js
+++ b/index.js
@@ -137,7 +137,7 @@ app.delete("/reset", async (req, res) => {
     await db.collection("stock_symbols").deleteMany({});
     await db.collection("stock_symbols").insertOne({ symbols: [] });
 
-    resetInMemoryData();
+    await resetInMemoryData();
     res.json({ status: "success", message: "Collections reset successfully" });
   } catch (err) {
     logError("reset collections", err);


### PR DESCRIPTION
## Summary
- Replace in-memory aligned tick storage with MongoDB collection
- Process and purge aligned ticks directly from the database
- Ensure DB reset and utilities clean aligned tick data

## Testing
- `npm test` (fails: Invalid state: Cannot mock '../kite.js.' The module is already mocked.)

------
https://chatgpt.com/codex/tasks/task_e_68b8d542437c8325af99913e22f2a454