### PR TITLE
refactor: fetch token-symbol mappings from DB

### DIFF
--- a/dataEngine.js
+++ b/dataEngine.js
@@ -1,4 +1,4 @@
-import { kc, initSession, tickBuffer, candleHistory, symbolTokenMap } from './kite.js';
+import { kc, initSession, tickBuffer, candleHistory, getTokenForSymbol } from './kite.js';
 import db from './db.js';
 import { logError } from './logger.js';
 
@@ -18,16 +18,7 @@ export async function getLTP(symbol) {
 }
 
 export async function getInstrumentToken(symbol) {
-  if (symbolTokenMap[symbol]) {
-    return symbolTokenMap[symbol];
-  }
-  await initSession();
-  const data = await kc.getLTP([symbol]);
-  const token = data?.[symbol]?.instrument_token;
-  if (token) {
-    symbolTokenMap[symbol] = token;
-  }
-  return token;
+  return await getTokenForSymbol(symbol);
 }
 
 export async function getFundamentals(symbol) {
@@ -48,4 +39,4 @@ export async function getNews(symbol) {
   }
 }
 
-export { candleHistory, symbolTokenMap, tickBuffer };
+export { candleHistory, tickBuffer };

--- a/orderExecution.js
+++ b/orderExecution.js
@@ -3,7 +3,7 @@ import dotenv from "dotenv";
 const logError = (ctx, err) => console.error(`[${ctx}]`, err?.message || err);
 import {
   kc,
-  symbolTokenMap,
+  getTokenForSymbol,
   initSession,
   onOrderUpdate,
   getHistoricalData,
@@ -188,7 +188,7 @@ export async function getMarginForStock(order) {
     await initSession();
     const response = await kc.orderMargins(order);
 
-    const token = symbolTokenMap[order.tradingsymbol];
+    const token = await getTokenForSymbol(order.tradingsymbol);
     const hist = await getHistoricalData(token);
     const avgRange =
       hist.length > 1

--- a/scanner.js
+++ b/scanner.js
@@ -12,8 +12,12 @@ import {
   isAwayFromConsolidation,
 } from "./util.js";
 
-import { getSupportResistanceLevels, getHistoricalData } from "./kite.js";
-import { candleHistory, symbolTokenMap } from "./dataEngine.js";
+import {
+  getSupportResistanceLevels,
+  getHistoricalData,
+  getTokenForSymbol,
+} from "./kite.js";
+import { candleHistory } from "./dataEngine.js";
 import { evaluateAllStrategies } from "./strategyEngine.js";
 import { evaluateStrategies } from "./strategies.js";
 import { RISK_REWARD_RATIO, calculatePositionSize } from "./positionSizing.js";
@@ -118,7 +122,7 @@ export async function analyzeCandles(
     const features = computeFeatures(validCandles);
     if (!features) return null;
 
-    const token = symbolTokenMap[symbol];
+    const token = await getTokenForSymbol(symbol);
     const dailyHistory = await getHistoricalData(token);
     const sessionData = candleHistory[token] || validCandles;
 
@@ -182,7 +186,7 @@ export async function analyzeCandles(
       return null;
     }
 
-    const { support, resistance } = getSupportResistanceLevels(symbol);
+    const { support, resistance } = await getSupportResistanceLevels(symbol);
 
     const stratResults = evaluateAllStrategies({
       ...context,

--- a/tests/analyzeCandles.test.js
+++ b/tests/analyzeCandles.test.js
@@ -21,11 +21,11 @@ const kiteMock = test.mock.module('../kite.js', {
     }),
     candleHistory: {},
     getHistoricalData: async () => [],
-    symbolTokenMap: {},
+    getTokenForSymbol: async () => 123,
     initSession: async () => 'token',
     kc: { getLTP: async (symbols) => ({ [symbols[0]]: { last_price: 100, instrument_token: 123 } }) },
     tickBuffer: {},
-    getSupportResistanceLevels: () => ({ support: 90, resistance: 110 }),
+    getSupportResistanceLevels: async () => ({ support: 90, resistance: 110 }),
     getMA: () => null,
     onOrderUpdate: () => {},
     orderEvents: { on: () => {} }

--- a/tests/canPlaceTrade.test.js
+++ b/tests/canPlaceTrade.test.js
@@ -7,7 +7,7 @@ const kiteMock = test.mock.module('../kite.js', {
     onOrderUpdate: () => {},
     orderEvents: { on: () => {} },
     kc: {},
-    symbolTokenMap: {},
+    getTokenForSymbol: async () => 123,
     getHistoricalData: async () => [],
     initSession: async () => {},
     getMA: () => null

--- a/tests/orderUpdate.test.js
+++ b/tests/orderUpdate.test.js
@@ -9,7 +9,7 @@ const kiteMock = test.mock.module('../kite.js', {
     orderEvents: emitter,
     onOrderUpdate: (cb) => emitter.on('update', cb),
     kc: {},
-    symbolTokenMap: {},
+    getTokenForSymbol: async () => 123,
     getHistoricalData: async () => [],
     initSession: async () => {},
     getMA: () => null

--- a/tests/sendOrderTag.test.js
+++ b/tests/sendOrderTag.test.js
@@ -5,7 +5,7 @@ process.env.NODE_ENV = 'test';
 const kiteMock = test.mock.module('../kite.js', {
   namedExports: {
     kc: { placeOrder: async (params) => params },
-    symbolTokenMap: {},
+    getTokenForSymbol: async () => 123,
     getHistoricalData: async () => [],
     initSession: async () => {},
     onOrderUpdate: () => {},


### PR DESCRIPTION
## Summary
- remove global token/symbol maps and add DB-backed lookups
- adapt modules and tests to fetch token and symbol mapping from database

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbb7fc80a483259f24bb8de80d1679