### PR TITLE
feat: add historical store with caching layer

### DIFF
--- a/data/historicalStore.js
+++ b/data/historicalStore.js
@@ -1,0 +1,282 @@
+import db from '../db.js';
+import { logError } from '../logger.js';
+
+const defaults = {
+  maxBarsDaily: 300,
+  maxBarsIntraday: 120,
+  dailyStaleMs: 6 * 60 * 60 * 1000,
+  intradayStaleMs: 5 * 60 * 1000,
+  enableChangeStream: false,
+  metrics: {},
+};
+
+function initHistoricalStore(options = {}) {
+  const cfg = { ...defaults, ...options };
+  const metrics = cfg.metrics || {};
+
+  const dailyCache = new Map();
+  const intradayCache = new Map();
+  const dailyLocks = new Map();
+  const intradayLocks = new Map();
+
+  let changeStreams = [];
+
+  const state = {
+    dailyModel: null, // 'single' | 'token'
+  };
+
+  function metric(name, ...args) {
+    try {
+      const fn = metrics[name];
+      if (typeof fn === 'function') fn(...args);
+    } catch (err) {
+      logError('historicalStore.metric', err);
+    }
+  }
+
+  function key(token) {
+    return String(token);
+  }
+
+  function isStale(entry, ttl) {
+    return !entry || Date.now() - entry.lastLoadedAt > ttl;
+  }
+
+  function withLock(map, token, fn) {
+    const k = key(token);
+    const prev = map.get(k) || Promise.resolve();
+    let release;
+    const p = new Promise((res) => (release = res));
+    map.set(k, prev.then(() => p));
+    return prev
+      .then(() => fn())
+      .finally(() => {
+        release();
+        if (map.get(k) === p) map.delete(k);
+      });
+  }
+
+  function dedupeAndSort(arr) {
+    const map = new Map();
+    for (const c of arr || []) {
+      const t = +new Date(c.date || c.timestamp);
+      if (!Number.isFinite(t)) continue;
+      if (!map.has(t)) map.set(t, { ...c, date: new Date(t).toISOString() });
+    }
+    return [...map.values()].sort((a, b) => +new Date(a.date) - +new Date(b.date));
+  }
+
+  async function detectDailyModel() {
+    if (state.dailyModel) return state.dailyModel;
+    try {
+      const doc = await db.collection('historical_data').findOne({});
+      if (doc && (doc.token || doc.candles)) {
+        state.dailyModel = 'token';
+      } else {
+        state.dailyModel = 'single';
+      }
+    } catch (err) {
+      logError('historicalStore.detectDailyModel', err);
+      state.dailyModel = 'single';
+    }
+    return state.dailyModel;
+  }
+
+  function sliceCandles(candles, { limit, from, to } = {}) {
+    let arr = candles || [];
+    if (from) {
+      const f = +new Date(from);
+      arr = arr.filter((c) => +new Date(c.date || c.timestamp) >= f);
+    }
+    if (to) {
+      const t = +new Date(to);
+      arr = arr.filter((c) => +new Date(c.date || c.timestamp) <= t);
+    }
+    if (limit) arr = arr.slice(-limit);
+    return arr;
+  }
+
+  async function loadDaily(token) {
+    const k = key(token);
+    const max = cfg.maxBarsDaily;
+    const start = Date.now();
+    try {
+      const col = db.collection('historical_data');
+      const limit = max;
+      // try single doc model first
+      const projection = { [k]: { $slice: -limit }, _id: 0 };
+      let doc = await col.findOne({}, { projection });
+      let arr = doc?.[k];
+      if (!arr) {
+        // per-token model
+        doc = await col.findOne(
+          { token: Number(k) },
+          { projection: { candles: { $slice: -limit }, data: { $slice: -limit }, _id: 0 } }
+        );
+        arr = doc?.candles || doc?.data;
+        if (arr) state.dailyModel = 'token';
+      } else {
+        state.dailyModel = 'single';
+      }
+      const candles = dedupeAndSort(arr || []).slice(-max);
+      dailyCache.set(k, { candles, lastLoadedAt: Date.now() });
+      metric('onLoadMs', Date.now() - start, 'daily');
+      return candles;
+    } catch (err) {
+      logError('historicalStore.loadDaily', err);
+      metric('onError', err, token, 'daily');
+      dailyCache.set(k, { candles: [], lastLoadedAt: Date.now() });
+      return [];
+    }
+  }
+
+  async function getDailyCandles(token, opts = {}) {
+    const k = key(token);
+    return withLock(dailyLocks, k, async () => {
+      let entry = dailyCache.get(k);
+      if (entry && !isStale(entry, cfg.dailyStaleMs)) {
+        metric('onHit', 'daily');
+        return sliceCandles(entry.candles, opts);
+      }
+      metric('onMiss', 'daily');
+      const candles = await loadDaily(k);
+      return sliceCandles(candles, opts);
+    });
+  }
+
+  async function appendDailyCandles(token, candles = []) {
+    const k = key(token);
+    return withLock(dailyLocks, k, async () => {
+      const entry = dailyCache.get(k) || { candles: [], lastLoadedAt: 0 };
+      const merged = dedupeAndSort([...entry.candles, ...candles]);
+      const bounded = merged.slice(-cfg.maxBarsDaily);
+      const start = Date.now();
+      try {
+        const model = await detectDailyModel();
+        const col = db.collection('historical_data');
+        if (model === 'single') {
+          await col.updateOne(
+            {},
+            { $push: { [k]: { $each: candles, $slice: -cfg.maxBarsDaily } } },
+            { upsert: true }
+          );
+        } else {
+          await col.updateOne(
+            { token: Number(k) },
+            { $push: { candles: { $each: candles, $slice: -cfg.maxBarsDaily } } },
+            { upsert: true }
+          );
+        }
+        metric('onWriteMs', Date.now() - start, 'daily');
+      } catch (err) {
+        logError('historicalStore.appendDailyCandles', err);
+        metric('onError', err, token, 'daily');
+      }
+      dailyCache.set(k, { candles: bounded, lastLoadedAt: Date.now() });
+      return bounded;
+    });
+  }
+
+  async function loadIntraday(token) {
+    const k = key(token);
+    const max = cfg.maxBarsIntraday;
+    const start = Date.now();
+    try {
+      const doc = await db
+        .collection('historical_session_data')
+        .findOne(
+          { token: Number(k) },
+          { projection: { candles: { $slice: -max }, data: { $slice: -max }, _id: 0 } }
+        );
+      const arr = doc?.candles || doc?.data || [];
+      const candles = dedupeAndSort(arr).slice(-max);
+      intradayCache.set(k, { candles, lastLoadedAt: Date.now() });
+      metric('onLoadMs', Date.now() - start, 'intraday');
+      return candles;
+    } catch (err) {
+      logError('historicalStore.loadIntraday', err);
+      metric('onError', err, token, 'intraday');
+      intradayCache.set(k, { candles: [], lastLoadedAt: Date.now() });
+      return [];
+    }
+  }
+
+  async function getIntradayCandles(token, opts = {}) {
+    const k = key(token);
+    return withLock(intradayLocks, k, async () => {
+      let entry = intradayCache.get(k);
+      if (entry && !isStale(entry, cfg.intradayStaleMs)) {
+        metric('onHit', 'intraday');
+        return sliceCandles(entry.candles, opts);
+      }
+      metric('onMiss', 'intraday');
+      const candles = await loadIntraday(k);
+      return sliceCandles(candles, opts);
+    });
+  }
+
+  async function appendIntradayCandles(token, candles = []) {
+    const k = key(token);
+    return withLock(intradayLocks, k, async () => {
+      const entry = intradayCache.get(k) || { candles: [], lastLoadedAt: 0 };
+      const merged = dedupeAndSort([...entry.candles, ...candles]);
+      const bounded = merged.slice(-cfg.maxBarsIntraday);
+      const start = Date.now();
+      try {
+        await db.collection('historical_session_data').updateOne(
+          { token: Number(k) },
+          { $push: { candles: { $each: candles, $slice: -cfg.maxBarsIntraday } } },
+          { upsert: true }
+        );
+        metric('onWriteMs', Date.now() - start, 'intraday');
+      } catch (err) {
+        logError('historicalStore.appendIntradayCandles', err);
+        metric('onError', err, token, 'intraday');
+      }
+      intradayCache.set(k, { candles: bounded, lastLoadedAt: Date.now() });
+      return bounded;
+    });
+  }
+
+  async function warmup(tokens = [], { daily = true, intraday = true } = {}) {
+    const arr = Array.from(tokens || []);
+    const tasks = [];
+    for (const t of arr) {
+      if (daily) tasks.push(getDailyCandles(t));
+      if (intraday) tasks.push(getIntradayCandles(t));
+    }
+    await Promise.all(tasks);
+  }
+
+  function invalidate(token, { scope = 'all' } = {}) {
+    const k = key(token);
+    if (scope === 'all' || scope === 'daily') dailyCache.delete(k);
+    if (scope === 'all' || scope === 'intraday') intradayCache.delete(k);
+  }
+
+  function shutdown() {
+    for (const cs of changeStreams) {
+      try {
+        cs.close();
+      } catch (_) {}
+    }
+    changeStreams = [];
+    dailyCache.clear();
+    intradayCache.clear();
+  }
+
+  return {
+    getDailyCandles,
+    getIntradayCandles,
+    appendDailyCandles,
+    appendIntradayCandles,
+    warmup,
+    invalidate,
+    shutdown,
+    _cache: { dailyCache, intradayCache },
+  };
+}
+
+export { initHistoricalStore };
+export default initHistoricalStore;
+

--- a/tests/historicalStore.test.js
+++ b/tests/historicalStore.test.js
@@ -1,0 +1,77 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+process.env.NODE_ENV = 'test';
+const db = (await import('../db.js')).default;
+const { default: initHistoricalStore } = await import('../data/historicalStore.js');
+
+function delay(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+async function resetCollections() {
+  await db.collection('historical_data').deleteMany({});
+  await db.collection('historical_session_data').deleteMany({});
+}
+
+test('read-through cache miss then hit', async () => {
+  await resetCollections();
+  await db.collection('historical_data').insertOne({ token: 1, candles: [
+    { date: '2020-01-01', open:1, high:1, low:1, close:1, volume:1 }
+  ]});
+  let miss=0, hit=0, loads=0;
+  const store = initHistoricalStore({ metrics:{ onMiss:()=>miss++, onHit:()=>hit++, onLoadMs:()=>loads++ } });
+  const first = await store.getDailyCandles(1);
+  assert.equal(first.length,1);
+  assert.equal(miss,1);
+  assert.equal(loads,1);
+  const second = await store.getDailyCandles(1);
+  assert.equal(hit,1);
+  assert.equal(loads,1); // still one load
+});
+
+test('TTL expiry triggers reload', async () => {
+  await resetCollections();
+  await db.collection('historical_data').insertOne({ token: 2, candles: [
+    { date: '2020-01-01', open:1, high:1, low:1, close:1, volume:1 }
+  ]});
+  let miss=0;
+  const store = initHistoricalStore({ dailyStaleMs: 10, metrics:{ onMiss:()=>miss++ } });
+  await store.getDailyCandles(2);
+  assert.equal(miss,1);
+  await delay(20);
+  await store.getDailyCandles(2);
+  assert.equal(miss,2);
+});
+
+test('write-through append dedupe and bounds', async () => {
+  await resetCollections();
+  const store = initHistoricalStore({ maxBarsDaily:2 });
+  const res = await store.appendDailyCandles(3, [
+    { date:'2020-01-01', open:1, high:1, low:1, close:1, volume:1 },
+    { date:'2020-01-02', open:2, high:2, low:2, close:2, volume:2 },
+    { date:'2020-01-02', open:2, high:2, low:2, close:2, volume:2 },
+    { date:'2019-12-31', open:0, high:0, low:0, close:0, volume:0 }
+  ]);
+  assert.equal(res.length,2); // bounded to 2 most recent
+    assert.equal(res[0].date.startsWith('2020-01-01'), true);
+    const doc = await db.collection('historical_data').findOne({});
+    const arr = doc.candles || doc['3'];
+    assert.equal(arr.length,2);
+});
+
+test('concurrent reads load once', async () => {
+  await resetCollections();
+  await db.collection('historical_data').insertOne({ token:4, candles:[{date:'2020-01-01',open:1,high:1,low:1,close:1,volume:1}]});
+  let loads=0;
+  const store = initHistoricalStore({ metrics:{ onLoadMs:()=>loads++ } });
+  await Promise.all([store.getDailyCandles(4), store.getDailyCandles(4)]);
+  assert.equal(loads,1);
+});
+
+test('supports single document schema', async () => {
+  await resetCollections();
+  await db.collection('historical_data').insertOne({ '5': [
+    { date:'2020-01-01', open:1, high:1, low:1, close:1, volume:1 }
+  ]});
+  const store = initHistoricalStore();
+  const candles = await store.getDailyCandles(5);
+  assert.equal(candles.length,1);
+});


### PR DESCRIPTION
## Summary
- add Mongo-backed historicalStore with read-through/write-through caching
- use historicalStore in kite.js helpers and gap calculations
- fix canPlaceTrade tests and add historicalStore coverage

## Testing
- `node --test --experimental-test-module-mocks tests/historicalStore.test.js`
- `npm test` *(fails: hangs after initial tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bc16a399dc8325bc2205648b647983