### PR TITLE
Persist execution state in MongoDB

### DIFF
--- a/db.js
+++ b/db.js
@@ -24,6 +24,9 @@ async function ensureIndexes(db) {
     { expiresAt: 1 },
     { expireAfterSeconds: 0 }
   );
+  await db.collection("retry_queue").createIndex({ nextAttempt: 1 });
+  await db.collection("open_trades").createIndex({ slId: 1 });
+  await db.collection("open_trades").createIndex({ targetId: 1 });
   // Ensure aligned tick storage exists for minute-level tick aggregation
   await db
     .collection("aligned_ticks")
@@ -63,4 +66,15 @@ export const connectDB = async (attempt = 0) => {
 const db = await connectDB();
 
 export default db;
+
+if (process.env.NODE_ENV === "test") {
+  process.once("exit", async () => {
+    try {
+      await client?.close();
+      await memoryServer?.stop();
+    } catch {
+      /* ignore */
+    }
+  });
+}
 

--- a/tests/orderUpdate.test.js
+++ b/tests/orderUpdate.test.js
@@ -16,17 +16,19 @@ const kiteMock = test.mock.module('../kite.js', {
   }
 });
 
-const { openTrades } = await import('../orderExecution.js');
+const { addOpenTrade, getOpenTrade } = await import('../orderExecution.js');
 
 let received;
 emitter.on('update', (u) => { received = u; });
 
-openTrades.set('e1', { entryId: 'e1', slId: 's1', targetId: 't1', status: 'OPEN' });
+await addOpenTrade('e1', { entryId: 'e1', slId: 's1', targetId: 't1', status: 'OPEN' });
 emitter.emit('update', { order_id: 'e1', status: 'COMPLETE' });
+await new Promise((r) => setTimeout(r, 10));
 
-test('order update listener updates trades map', () => {
+test('order update listener updates trades map', async () => {
   assert.deepEqual(received, { order_id: 'e1', status: 'COMPLETE' });
-  assert.equal(openTrades.has('e1'), false);
+  const trade = await getOpenTrade('e1');
+  assert.equal(trade, null);
 });
 
 kiteMock.restore();


### PR DESCRIPTION
## Summary
- Persist failed signal retry queue in MongoDB
- Store open trade records in an `open_trades` collection
- Index new collections and clean up DB connections in tests

## Testing
- `node --test --experimental-test-module-mocks tests/orderUpdate.test.js` *(fails: process hangs after test completion)*

------
https://chatgpt.com/codex/tasks/task_e_68bd956cfaf48325b25ad740d09ddb18