### PR TITLE
Fix duplicate export in kite module

### DIFF
--- a/kite.js
+++ b/kite.js
@@ -1499,6 +1499,5 @@ export {
   getHistoricalData,
   resetInMemoryData,
   loadTickDataFromDB,
-  rebuildThreeMinCandlesFromOneMin,
   lastTickTs,
 };


### PR DESCRIPTION
## Summary
- Remove duplicate named export for `rebuildThreeMinCandlesFromOneMin` to resolve runtime SyntaxError

## Testing
- `npm test`
- `node index.js` *(fails: querySrv ENOTFOUND _mongodb._tcp.cluster0.53r8xqg.mongodb.net)*

------
https://chatgpt.com/codex/tasks/task_e_68be8f7f86548325b4f69f84aae4379c