### PR TITLE
fix duplicate exports in kite.js

### DIFF
--- a/kite.js
+++ b/kite.js
@@ -1499,7 +1499,5 @@ export {
   getHistoricalData,
   resetInMemoryData,
   loadTickDataFromDB,
-  rebuildThreeMinCandlesFromOneMin,
-  getSupportResistanceLevels,
   lastTickTs,
 };


### PR DESCRIPTION
## Summary
- remove duplicate exports of getSupportResistanceLevels and rebuildThreeMinCandlesFromOneMin

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf1f618d208325acb38b40cf932f18