### PR TITLE
chore: standardize live feed logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,8 +258,8 @@ tests/
 3. **Start server**  
    `npm start` before 09:15 IST. Startup log should include `♻️ Loaded access token from DB`.
 
-4. **During market hours**  
-   When `isMarketOpen()` is true the log shows `🕒 Market open; starting live feed…` followed by `📈 Ticker connected` and subscription count. Signals will stream through Socket.IO and persist in MongoDB.
+4. **During market hours**
+   When `isMarketOpen()` is true the log shows `🕒 Market open; starting live feed…` followed by `📈 Ticker connected` and `🔔 Subscribed N symbols`. Signals will stream through Socket.IO and persist in MongoDB.
 
 5. **After hours / weekends**  
    The backend skips live feed and waits for next open.
@@ -268,9 +268,9 @@ tests/
 
 1. **Session load** – With a valid token doc, startup logs `♻️ Loaded access token from DB`.
 2. **Universe seed** – Empty `stock_symbols` results in `🌱 Seeded stock_symbols with defaults: [...]`.
-3. **Live feed starts** – During market hours logs `🕒 Market open; starting live feed…` and `📈 Ticker connected` with subscription count.
+3. **Live feed starts** – During market hours logs `🕒 Market open; starting live feed…`, `📈 Ticker connected`, and `🔔 Subscribed N symbols`.
 4. **Signals flow** – With session and universe during market hours, new documents appear in `signals` collection and are emitted via WebSocket.
-5. **Guard conditions** – Without a session or outside market hours logs `⚠️ No Kite session; live feed will not start.` or `⏸ Market closed. Skipping live feed start.`
+5. **Guard conditions** – Without a session or outside market hours logs `⚠️ No Kite session; live feed will not start.` or `⛔ Market closed: not starting live feed.`
 
 ## 🗺️ Roadmap
 

--- a/index.js
+++ b/index.js
@@ -310,9 +310,7 @@ server.listen(3000, async () => {
       console.log("🕒 Market open; starting live feed…");
       startLiveFeed(io);
     } else {
-      console.log(
-        "🕒 Market closed; live feed will start automatically on next open if implemented via scheduler."
-      );
+      console.log("⛔ Market closed: not starting live feed.");
     }
   } catch (e) {
     logError("server.listen init", e);

--- a/kite.js
+++ b/kite.js
@@ -367,7 +367,7 @@ async function preloadStockData() {
 async function startLiveFeed(io) {
   globalIO = io;
   if (!isMarketOpen()) {
-    console.log("⏸ Market closed. Skipping live feed start.");
+    console.log("⛔ Market closed: not starting live feed.");
     return;
   }
 
@@ -426,7 +426,7 @@ async function startLiveFeed(io) {
     ticker.subscribe(instrumentTokens);
     ticker.setMode(ticker.modeFull, instrumentTokens);
     console.log("📈 Ticker connected");
-    console.log(`Subscribed ${instrumentTokens.length} symbols`);
+    console.log("🔔 Subscribed", instrumentTokens.length, "symbols");
   });
 
   ticker.on("ticks", (ticks) => {


### PR DESCRIPTION
## Summary
- standardize market session log messages for startLiveFeed
- document subscription and market-closed behavior in runbook

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf91b5fddc8325b9ba07b8d74f25ac