### PR TITLE
Remove static stock seeding

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,8 +252,8 @@ tests/
 1. **Insert Kite session token**  
    Ensure a document `{ type: "kite_session", access_token: "<token>" }` exists in the `tokens` collection.
 
-2. **Prepare universe (optional)**  
-   The server seeds a default universe if `stock_symbols.symbols` is empty. POST `/addStockSymbol` to add more.
+2. **Prepare universe (optional)**
+   The server initializes an empty universe if `stock_symbols` is missing. Use POST `/addStockSymbol` to add symbols.
 
 3. **Start server**  
    `npm start` before 09:15 IST. Startup log should include `♻️ Loaded access token from DB`.
@@ -267,7 +267,7 @@ tests/
 ## ✅ Acceptance Tests
 
 1. **Session load** – With a valid token doc, startup logs `♻️ Loaded access token from DB`.
-2. **Universe seed** – Empty `stock_symbols` results in `🌱 Seeded stock_symbols with defaults: [...]`.
+2. **Universe initialization** – On first run logs `🌱 Initialized stock_symbols with empty list`.
 3. **Live feed starts** – During market hours logs `🕒 Market open; starting live feed…`, `📈 Ticker connected`, and `🔔 Subscribed N symbols`.
 4. **Signals flow** – With session and universe during market hours, new documents appear in `signals` collection and are emitted via WebSocket.
 5. **Guard conditions** – Without a session or outside market hours logs `⚠️ No Kite session; live feed will not start.` or `⛔ Market closed: not starting live feed.`

--- a/index.js
+++ b/index.js
@@ -79,10 +79,12 @@ app.use(express.json());
 async function ensureUniverseSeeded(db) {
   const col = db.collection("stock_symbols");
   const doc = await col.findOne({});
-  if (!doc || !Array.isArray(doc.symbols) || doc.symbols.length === 0) {
-    const seed = ["RELIANCE", "HDFCBANK", "INFY"];
-    await col.updateOne({}, { $set: { symbols: seed } }, { upsert: true });
-    console.log("🌱 Seeded stock_symbols with defaults:", seed);
+  if (!doc) {
+    await col.insertOne({ symbols: [] });
+    console.log("🌱 Initialized stock_symbols with empty list");
+  } else if (!Array.isArray(doc.symbols)) {
+    await col.updateOne({}, { $set: { symbols: [] } });
+    console.log("🌱 Reset stock_symbols to empty list");
   } else {
     console.log("✅ Universe present:", doc.symbols.length, "symbols");
   }


### PR DESCRIPTION
## Summary
- initialize stock_symbols collection empty instead of seeding defaults
- update runbook docs to reflect manual universe management

## Testing
- `npm test` *(hangs after initial tests; partial output shows several tests passing)*

------
https://chatgpt.com/codex/tasks/task_e_68c775d38b3c83258f8d7473d4cf0a83