### PR TITLE
Refine token mapping, metrics, and alignment pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,16 @@ Trigger historical backfill.
 { "interval": "minute", "days": 3 }
 ```
 
+### Rebuild today's aligned candles
+
+If the live aligner misses a window you can rebuild the 1‑minute series for the current trading day:
+
+```bash
+node backfillToday.js
+```
+
+The script reads `tick_data`, feeds the aligner, and upserts both `aligned_ticks` and `session_data` for the day (09:15–15:30 IST).
+
 ### GET `/kite-redirect`
 
 OAuth redirect capture for Kite `request_token` → creates/refreshes the trading session.

--- a/aligner.js
+++ b/aligner.js
@@ -1,0 +1,224 @@
+import db from "./db.js";
+import { canonToken } from "./canon.js";
+import { logError } from "./logger.js";
+import { incrementMetric } from "./metrics.js";
+
+const MINUTE_MS = 60 * 1000;
+export const WATERMARK_MS = 3000;
+
+const openBuckets = new Map(); // token -> Map(minuteMs -> bucket)
+const finalizedCandles = [];
+
+function ensureTokenBuckets(token) {
+  const tokenStr = canonToken(token);
+  if (!openBuckets.has(tokenStr)) {
+    openBuckets.set(tokenStr, new Map());
+  }
+  return openBuckets.get(tokenStr);
+}
+
+function getMinuteStart(timestamp) {
+  const ts = timestamp ? new Date(timestamp) : new Date();
+  const minute = new Date(ts);
+  minute.setSeconds(0, 0);
+  return minute.getTime();
+}
+
+function formatMinuteIST(minuteMs) {
+  const d = new Date(minuteMs);
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  const hours = String(d.getHours()).padStart(2, "0");
+  const minutes = String(d.getMinutes()).padStart(2, "0");
+  return `${year}-${month}-${day}T${hours}:${minutes}:00`;
+}
+
+function getSessionDate(minuteMs) {
+  const d = new Date(minuteMs);
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function finalizeBucket(bucket) {
+  if (!bucket || !bucket.ticks.length) return;
+  const { token, symbol, minuteMs } = bucket;
+  const prices = bucket.ticks
+    .map((tick) => Number(tick.last_price))
+    .filter((price) => Number.isFinite(price));
+  if (!prices.length) return;
+
+  const open = prices[0];
+  const close = prices[prices.length - 1];
+  const high = Math.max(...prices);
+  const low = Math.min(...prices);
+  const volume = bucket.ticks.reduce((sum, tick) => {
+    const qty = Number(
+      tick.last_traded_quantity ?? tick.volume ?? tick.volume_traded ?? 0
+    );
+    if (!Number.isFinite(qty)) return sum;
+    return sum + qty;
+  }, 0);
+  const trades = bucket.ticks.length;
+  const minuteDate = new Date(minuteMs);
+
+  finalizedCandles.push({
+    token: Number(token),
+    tokenStr: token,
+    symbol,
+    minute: minuteDate,
+    minuteIST: formatMinuteIST(minuteMs),
+    session: getSessionDate(minuteMs),
+    open,
+    high,
+    low,
+    close,
+    volume,
+    trades,
+    ticks: bucket.ticks.length,
+    lastTick: bucket.ticks[bucket.ticks.length - 1],
+    createdAt: new Date(),
+  });
+  incrementMetric("candles1mFormed");
+}
+
+function finalizeBucketsUntil(cutoffMs) {
+  for (const [token, buckets] of openBuckets.entries()) {
+    for (const [minuteMs, bucket] of buckets.entries()) {
+      if (minuteMs <= cutoffMs) {
+        finalizeBucket(bucket);
+        buckets.delete(minuteMs);
+      }
+    }
+    if (buckets.size === 0) {
+      openBuckets.delete(token);
+    }
+  }
+}
+
+function finalizeReadyBuckets(nowMs = Date.now()) {
+  const cutoff = nowMs - WATERMARK_MS - MINUTE_MS;
+  for (const [token, buckets] of openBuckets.entries()) {
+    for (const [minuteMs, bucket] of buckets.entries()) {
+      if (minuteMs <= cutoff) {
+        finalizeBucket(bucket);
+        buckets.delete(minuteMs);
+      }
+    }
+    if (buckets.size === 0) {
+      openBuckets.delete(token);
+    }
+  }
+}
+
+export function ingestTick({ token, symbol, tick }) {
+  const tokenStr = canonToken(token);
+  if (!tokenStr || !symbol) return;
+  const minuteMs = getMinuteStart(tick.timestamp || Date.now());
+  const buckets = ensureTokenBuckets(tokenStr);
+  if (!buckets.has(minuteMs)) {
+    buckets.set(minuteMs, {
+      token: tokenStr,
+      symbol,
+      minuteMs,
+      ticks: [],
+    });
+  }
+  const bucket = buckets.get(minuteMs);
+  bucket.ticks.push(tick);
+  bucket.lastSeen = Date.now();
+  finalizeReadyBuckets(Date.now());
+}
+
+export async function persistAlignedCandleBatch() {
+  if (!finalizedCandles.length) return;
+  const toPersist = finalizedCandles.splice(0);
+  const alignedOps = toPersist.map((doc) => ({
+    updateOne: {
+      filter: { token: doc.token, minute: doc.minute },
+      update: {
+        $set: {
+          token: doc.token,
+          symbol: doc.symbol,
+          minute: doc.minute,
+          minuteIST: doc.minuteIST,
+          session: doc.session,
+          open: doc.open,
+          high: doc.high,
+          low: doc.low,
+          close: doc.close,
+          volume: doc.volume,
+          trades: doc.trades,
+          ticks: doc.ticks,
+          lastTick: doc.lastTick,
+          updatedAt: new Date(),
+        },
+        $setOnInsert: { createdAt: doc.createdAt },
+      },
+      upsert: true,
+    },
+  }));
+
+  const sessionOps = toPersist.map((doc) => ({
+    updateOne: {
+      filter: { token: doc.token, ts: doc.minute },
+      update: {
+        $set: {
+          token: doc.token,
+          symbol: doc.symbol,
+          ts: doc.minute,
+          minute: doc.minuteIST,
+          session: doc.session,
+          open: doc.open,
+          high: doc.high,
+          low: doc.low,
+          close: doc.close,
+          volume: doc.volume,
+          trades: doc.trades,
+          updatedAt: new Date(),
+        },
+        $setOnInsert: { createdAt: doc.createdAt },
+      },
+      upsert: true,
+    },
+  }));
+
+  try {
+    if (alignedOps.length) {
+      await db.collection("aligned_ticks").bulkWrite(alignedOps, { ordered: false });
+    }
+    if (sessionOps.length) {
+      await db.collection("session_data").bulkWrite(sessionOps, { ordered: false });
+    }
+  } catch (err) {
+    logError("aligner.persistAlignedCandleBatch", err);
+  }
+}
+
+export async function flushOpenCandles({ force = false } = {}) {
+  if (force) {
+    finalizeBucketsUntil(Number.POSITIVE_INFINITY);
+  } else {
+    finalizeReadyBuckets(Date.now());
+  }
+  await persistAlignedCandleBatch();
+}
+
+export async function finalizeEOD(reference = new Date()) {
+  const eod = new Date(reference);
+  eod.setHours(15, 30, 0, 0);
+  finalizeBucketsUntil(eod.getTime());
+  await persistAlignedCandleBatch();
+}
+
+export function getOpenBucketsSnapshot() {
+  const snapshot = [];
+  for (const [token, buckets] of openBuckets.entries()) {
+    for (const bucket of buckets.values()) {
+      snapshot.push({ token, minute: new Date(bucket.minuteMs), ticks: bucket.ticks.length });
+    }
+  }
+  return snapshot;
+}

--- a/auditLogger.js
+++ b/auditLogger.js
@@ -1,6 +1,7 @@
 import crypto from 'crypto';
 import db from './db.js';
 import { sendNotification } from './telegram.js';
+import { onReject } from './metrics.js';
 
 const LOG_COLLECTION = 'audit_logs';
 const ARCHIVE_COLLECTION = 'audit_logs_archive';
@@ -82,6 +83,7 @@ export async function logSignalRejected(
   validationDetails,
   signalData = null
 ) {
+  onReject(reasonCode);
   await secureLogStore(
     {
       type: 'signal_rejected',

--- a/backfillToday.js
+++ b/backfillToday.js
@@ -1,0 +1,121 @@
+import "./env.js";
+import db from "./db.js";
+import { ensureLoad as ensureInstrumentMap, tokenSymbolMap } from "./mapping.js";
+import { fallbackFetch } from "./fallbackFetcher.js";
+import { canonToken } from "./canon.js";
+import { ingestTick as ingestAlignedTick, flushOpenCandles } from "./aligner.js";
+import { logError } from "./logger.js";
+
+function getSessionRange() {
+  const now = new Date();
+  const start = new Date(now);
+  start.setHours(9, 15, 0, 0);
+  const end = new Date(now);
+  end.setHours(15, 31, 0, 0);
+  return { start, end };
+}
+
+function formatMinute(date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  return `${year}-${month}-${day}T${hours}:${minutes}:00`;
+}
+
+function formatSession(date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+async function rebuildSessionData(start, end) {
+  const docs = await db
+    .collection("aligned_ticks")
+    .find({ minute: { $gte: start, $lt: end } })
+    .toArray();
+
+  if (!docs.length) {
+    console.log("⚠️ No aligned ticks found for today. Skipping session rebuild.");
+    return;
+  }
+
+  const ops = docs.map((doc) => {
+    const minute = new Date(doc.minute);
+    return {
+      updateOne: {
+        filter: { token: doc.token, ts: minute },
+        update: {
+          $set: {
+            token: doc.token,
+            symbol: doc.symbol,
+            ts: minute,
+            minute: formatMinute(minute),
+            session: formatSession(minute),
+            open: doc.open,
+            high: doc.high,
+            low: doc.low,
+            close: doc.close,
+            volume: doc.volume,
+            trades: doc.trades || 0,
+            updatedAt: new Date(),
+          },
+          $setOnInsert: { createdAt: new Date() },
+        },
+        upsert: true,
+      },
+    };
+  });
+
+  await db.collection("session_data").bulkWrite(ops, { ordered: false });
+  console.log(`✅ Rebuilt session_data with ${docs.length} candles.`);
+}
+
+async function backfillToday() {
+  const { start, end } = getSessionRange();
+  await ensureInstrumentMap(db);
+
+  const cursor = db
+    .collection("tick_data")
+    .find({ timestamp: { $gte: start, $lt: end } })
+    .sort({ timestamp: 1 });
+
+  let processed = 0;
+
+  try {
+    for await (const tick of cursor) {
+      const tokenStr = canonToken(tick.instrument_token || tick.token);
+      if (!tokenStr) continue;
+      let symbol = tokenSymbolMap.get(tokenStr);
+      if (!symbol) {
+        try {
+          const resolved = await fallbackFetch(tokenStr, null, db);
+          symbol = resolved?.symbol;
+        } catch (err) {
+          logError("backfill.resolve", err, { token: tokenStr });
+        }
+      }
+      if (!symbol) continue;
+      ingestAlignedTick({ token: tokenStr, symbol, tick });
+      processed += 1;
+    }
+
+    await flushOpenCandles({ force: true });
+    console.log(`✅ Ingested ${processed} ticks into aligner.`);
+    await rebuildSessionData(start, end);
+  } catch (err) {
+    logError("backfillToday", err);
+  }
+}
+
+backfillToday()
+  .then(() => {
+    console.log("✅ Backfill complete");
+    process.exit(0);
+  })
+  .catch((err) => {
+    logError("backfillToday.main", err);
+    process.exit(1);
+  });

--- a/canon.js
+++ b/canon.js
@@ -1,0 +1,36 @@
+const DEFAULT_EXCHANGE = "NSE";
+const EXCHANGE_PREFIX_REGEX = /^(NSE|BSE|MCX|NFO|CDS)/;
+
+export function canonToken(token) {
+  if (token === null || token === undefined) return "";
+  if (typeof token === "object" && token.instrument_token !== undefined) {
+    return String(token.instrument_token);
+  }
+  return String(token);
+}
+
+export function canonSymbol(value) {
+  if (value === null || value === undefined) return "";
+  let raw = String(value).trim();
+  if (!raw) return "";
+  raw = raw.toUpperCase();
+
+  if (raw.includes(":")) {
+    const [exchangePart, ...symbolParts] = raw.split(":");
+    const exchange = exchangePart || DEFAULT_EXCHANGE;
+    const symbol = symbolParts.join(":") || "";
+    return `${exchange}:${symbol}`;
+  }
+
+  const match = raw.match(EXCHANGE_PREFIX_REGEX);
+  if (match) {
+    const exchange = match[0];
+    const symbol = raw.slice(exchange.length);
+    if (symbol.startsWith(":")) {
+      return `${exchange}:${symbol.slice(1)}`;
+    }
+    return `${exchange}:${symbol}`;
+  }
+
+  return `${DEFAULT_EXCHANGE}:${raw}`;
+}

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,28 @@
+# Observability and Metrics
+
+The live worker periodically prints a compact metrics snapshot every minute. A typical log line looks like:
+
+```
+[metrics] {"ts":"2024-09-20T10:05:00.000Z","ticks":1240,"candles1mFormed":28,"evalSymbols":42,"candidates":3,"emitted":1,"rejectedBy":{"portfolioRules":2}}
+```
+
+Key counters:
+
+- **ticks** – number of raw ticks ingested from the Kite websocket during the interval.
+- **candles1mFormed** – count of one-minute candles closed by the aligner.
+- **evalSymbols** – symbols evaluated by strategy logic (both realtime and aligned flows).
+- **candidates** – signals considered before portfolio filters.
+- **emitted** – signals persisted and announced to sinks (Telegram, sockets, etc.).
+- **rejectedBy** – per-rule rejection counters. Each key maps to the filter/reason code that blocked a candidate.
+
+Use the `rejectedBy` object to understand which guardrail is suppressing signals. A healthy run should show non-zero `candidates`. If `emitted` remains zero, check the dominant entry in `rejectedBy` for the blocking rule (for example `portfolioRules`, `exposure`, `vwapGuard`).
+
+The logger also aggregates noisy warnings. Instead of repeating the same line for every unmapped token, the runtime emits summaries such as:
+
+```
+[WARN:UNMAPPED_TOKEN] total=37 unique=5 top=6469121:12,502:9
+```
+
+This means 37 unmapped ticks were observed across 5 tokens during the last aggregation window. Investigate the top offenders and ensure the instrument map contains the correct token.
+
+For manual backfills you can run `node backfillToday.js` to rebuild aligned candles and session data for the current trading day.

--- a/emitter.js
+++ b/emitter.js
@@ -1,0 +1,54 @@
+import db from "./db.js";
+import { logError } from "./logger.js";
+import { addSignal } from "./signalManager.js";
+import { sendSignal as sendTelegram } from "./telegram.js";
+
+function buildSignalFilter(result) {
+  if (result?.insertedId) {
+    return { _id: result.insertedId };
+  }
+  if (result?.signalId) {
+    return { signalId: result.signalId };
+  }
+  return null;
+}
+
+export async function persistThenNotify(signal, { sendFn = sendTelegram } = {}) {
+  const persistResult = await addSignal(signal);
+  const filter = buildSignalFilter(persistResult);
+  const sinks = { telegram: "pending" };
+
+  if (filter) {
+    await db.collection("signals").updateOne(filter, {
+      $set: { sinks, updatedAt: new Date() },
+      $setOnInsert: { createdAt: new Date() },
+    });
+  }
+
+  try {
+    if (typeof sendFn === "function") {
+      await sendFn(signal);
+    }
+    sinks.telegram = "ok";
+    if (filter) {
+      await db
+        .collection("signals")
+        .updateOne(filter, { $set: { "sinks.telegram": "ok", updatedAt: new Date() } });
+    }
+  } catch (err) {
+    sinks.telegram = "fail";
+    sinks.telegram_error = err?.message || String(err);
+    logError("emitter.telegram", err);
+    if (filter) {
+      await db.collection("signals").updateOne(filter, {
+        $set: {
+          "sinks.telegram": "fail",
+          "sinks.telegram_error": sinks.telegram_error,
+          updatedAt: new Date(),
+        },
+      });
+    }
+  }
+
+  return { ...persistResult, sinks };
+}

--- a/env.js
+++ b/env.js
@@ -1,0 +1,5 @@
+if (!process.env.TZ) {
+  process.env.TZ = "Asia/Kolkata";
+}
+
+export const TIMEZONE = process.env.TZ;

--- a/fallbackFetcher.js
+++ b/fallbackFetcher.js
@@ -1,0 +1,59 @@
+import db from "./db.js";
+import { canonSymbol, canonToken } from "./canon.js";
+import { setMapping, tokenSymbolMap, symbolTokenMap } from "./mapping.js";
+
+function buildInstrumentQuery(symOrToken) {
+  const clauses = [];
+  const token = Number(symOrToken);
+  if (!Number.isNaN(token)) {
+    clauses.push({ instrument_token: token });
+  }
+  const symbolKey = canonSymbol(symOrToken).split(":")[1];
+  if (symbolKey) {
+    clauses.push({ tradingsymbol: symbolKey });
+  }
+  return {
+    exchange: "NSE",
+    $or: clauses.length ? clauses : [{ tradingsymbol: symbolKey }],
+  };
+}
+
+export async function resolveInstrument(symOrToken, database = db) {
+  const tokenKey = canonToken(symOrToken);
+  let symbol = tokenSymbolMap.get(tokenKey);
+  if (!symbol) {
+    const symbolKey = canonSymbol(symOrToken);
+    const tokenFromSymbol = symbolTokenMap.get(symbolKey);
+    if (tokenFromSymbol) {
+      symbol = symbolKey;
+      setMapping(tokenFromSymbol, symbolKey);
+      return { token: canonToken(tokenFromSymbol), symbol: symbolKey };
+    }
+  } else {
+    return { token: tokenKey, symbol };
+  }
+
+  const query = buildInstrumentQuery(symOrToken);
+  const doc = await database.collection("instruments").findOne(query);
+  if (!doc) {
+    return { token: tokenKey || null, symbol: null };
+  }
+
+  const resolvedToken = canonToken(doc.instrument_token);
+  const resolvedSymbol = canonSymbol(`${doc.exchange || "NSE"}:${doc.tradingsymbol}`);
+  setMapping(resolvedToken, resolvedSymbol);
+  return { token: resolvedToken, symbol: resolvedSymbol, instrument: doc };
+}
+
+export async function fallbackFetch(symOrToken, fetchFn, database = db) {
+  const { token, symbol } = await resolveInstrument(symOrToken, database);
+  if (!symbol) {
+    const err = new Error("MAPPING_STILL_MISSING");
+    err.code = "MAPPING_STILL_MISSING";
+    throw err;
+  }
+  if (typeof fetchFn === "function") {
+    return fetchFn({ token, symbol });
+  }
+  return { token, symbol };
+}

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 // Index.js
+import "./env.js";
 import express from "express";
 import http from "http";
 import { Server } from "socket.io";
@@ -22,7 +23,6 @@ import {
   tickBuffer,
   lastTickTs,
 } from "./kite.js";
-import { sendSignal } from "./telegram.js";
 import {
   trackOpenPositions,
   checkExposureLimits,

--- a/logger.js
+++ b/logger.js
@@ -1,12 +1,92 @@
-import { sendNotification } from './telegram.js';
+import { sendNotification } from "./telegram.js";
+import { canonToken } from "./canon.js";
 
-export function logError(context, err) {
-  console.error(`[${context}]`, err);
-  try {
-    if (sendNotification) {
-      sendNotification(`[ERROR] ${context}: ${err.message || err}`);
-    }
-  } catch (e) {
-    console.error('[logError] Failed to send notification', e);
+const TOKEN_WARN_TTL_MS = 10 * 60 * 1000;
+const ERROR_DEDUPE_TTL_MS = 60 * 1000;
+const WARN_AGGREGATE_INTERVAL_MS = 60 * 1000;
+const warnDedupe = new Map();
+const warnAggregates = new Map();
+const errorDedupe = new Map();
+let aggregateTimer = null;
+
+function ensureAggregateTimer() {
+  if (aggregateTimer) return;
+  aggregateTimer = setInterval(() => {
+    flushWarnAggregates();
+  }, WARN_AGGREGATE_INTERVAL_MS);
+  if (aggregateTimer.unref) aggregateTimer.unref();
+}
+
+function flushWarnAggregates() {
+  if (!warnAggregates.size) return;
+  for (const [code, entry] of warnAggregates.entries()) {
+    const { total, tokens } = entry;
+    const sortedTokens = [...tokens.entries()].sort((a, b) => b[1] - a[1]);
+    const topTokens = sortedTokens.slice(0, 5).map(([token, count]) => `${token}:${count}`);
+    console.warn(
+      `[WARN:${code}] total=${total} unique=${tokens.size}` +
+        (topTokens.length ? ` top=${topTokens.join(",")}` : "")
+    );
   }
+  warnAggregates.clear();
+}
+
+function recordWarnAggregate(code, token) {
+  ensureAggregateTimer();
+  const entry = warnAggregates.get(code) || { total: 0, tokens: new Map() };
+  entry.total += 1;
+  const tokenCount = entry.tokens.get(token) || 0;
+  entry.tokens.set(token, tokenCount + 1);
+  warnAggregates.set(code, entry);
+}
+
+export function logWarnOncePerToken(code, token, message, extras = {}) {
+  const tokenStr = canonToken(token);
+  if (!tokenStr) return;
+  recordWarnAggregate(code, tokenStr);
+
+  const key = `${code}:${tokenStr}`;
+  const now = Date.now();
+  const last = warnDedupe.get(key);
+  if (last && now - last < TOKEN_WARN_TTL_MS) {
+    return;
+  }
+  warnDedupe.set(key, now);
+
+  const payload = Object.keys(extras).length ? ` ${JSON.stringify(extras)}` : "";
+  console.warn(`[WARN:${code}] token=${tokenStr} ${message}${payload}`);
+}
+
+export function logWarn(context, message, extras = {}) {
+  const payload = Object.keys(extras).length ? ` ${JSON.stringify(extras)}` : "";
+  console.warn(`[${context}] ${message}${payload}`);
+}
+
+export function logError(context, err, extras = {}) {
+  const message = err?.message || err;
+  const key = `${context}:${message}`;
+  const now = Date.now();
+  const last = errorDedupe.get(key);
+  if (last && now - last < ERROR_DEDUPE_TTL_MS) {
+    return;
+  }
+  errorDedupe.set(key, now);
+
+  const payload = Object.keys(extras).length ? ` ${JSON.stringify(extras)}` : "";
+  console.error(`[${context}] ${message}${payload}`);
+  if (err?.stack) {
+    console.error(err.stack);
+  }
+
+  try {
+    if (typeof sendNotification === "function") {
+      sendNotification(`[ERROR] ${context}: ${message}`);
+    }
+  } catch (notifyErr) {
+    console.error("[logError] Failed to send notification", notifyErr);
+  }
+}
+
+export function flushLoggerAggregates() {
+  flushWarnAggregates();
 }

--- a/mapping.js
+++ b/mapping.js
@@ -1,0 +1,70 @@
+import { canonSymbol, canonToken } from "./canon.js";
+
+export const tokenSymbolMap = new Map();
+export const symbolTokenMap = new Map();
+
+let loadPromise = null;
+
+export function setMapping(token, symbol) {
+  const tokenStr = canonToken(token);
+  const symbolStr = canonSymbol(symbol);
+  if (!tokenStr || !symbolStr) return;
+  tokenSymbolMap.set(tokenStr, symbolStr);
+  symbolTokenMap.set(symbolStr, tokenStr);
+}
+
+export function deleteMapping(tokenOrSymbol) {
+  const tokenKey = canonToken(tokenOrSymbol);
+  if (tokenSymbolMap.has(tokenKey)) {
+    const sym = tokenSymbolMap.get(tokenKey);
+    tokenSymbolMap.delete(tokenKey);
+    if (sym) symbolTokenMap.delete(sym);
+    return;
+  }
+
+  const symbolKey = canonSymbol(tokenOrSymbol);
+  if (symbolTokenMap.has(symbolKey)) {
+    const tok = symbolTokenMap.get(symbolKey);
+    symbolTokenMap.delete(symbolKey);
+    if (tok) tokenSymbolMap.delete(tok);
+  }
+}
+
+export function getSymbolForToken(token) {
+  return tokenSymbolMap.get(canonToken(token));
+}
+
+export function getTokenForSymbol(symbol) {
+  return symbolTokenMap.get(canonSymbol(symbol));
+}
+
+export function mappingLoaded() {
+  return tokenSymbolMap.size > 0;
+}
+
+export async function loadInstrumentsFromDB(db) {
+  if (!db) throw new Error("loadInstrumentsFromDB requires a database handle");
+  tokenSymbolMap.clear();
+  symbolTokenMap.clear();
+  const list = await db
+    .collection("instruments")
+    .find({ exchange: "NSE" })
+    .project({ instrument_token: 1, tradingsymbol: 1, exchange: 1 })
+    .toArray();
+  for (const instrument of list) {
+    const token = instrument.instrument_token;
+    const symbol = `${instrument.exchange || "NSE"}:${instrument.tradingsymbol}`;
+    setMapping(token, symbol);
+  }
+  return list.length;
+}
+
+export function ensureLoad(db) {
+  if (mappingLoaded()) return Promise.resolve(tokenSymbolMap.size);
+  if (!loadPromise) {
+    loadPromise = loadInstrumentsFromDB(db).finally(() => {
+      loadPromise = null;
+    });
+  }
+  return loadPromise;
+}

--- a/metrics.js
+++ b/metrics.js
@@ -1,0 +1,96 @@
+const DEFAULT_INTERVAL_MS = 60000;
+
+export const metrics = {
+  ticks: 0,
+  candles1mFormed: 0,
+  evalSymbols: 0,
+  candidates: 0,
+  emitted: 0,
+  rejectedBy: {},
+};
+
+let reporterStarted = false;
+let reporterTimer = null;
+let loggerFn = console.log;
+
+export function setLogger(fn) {
+  if (typeof fn === "function") {
+    loggerFn = fn;
+  }
+}
+
+export function incrementMetric(name, value = 1) {
+  if (!Object.prototype.hasOwnProperty.call(metrics, name)) {
+    metrics[name] = 0;
+  }
+  const current = Number(metrics[name]) || 0;
+  metrics[name] = current + value;
+  return metrics[name];
+}
+
+export function setMetric(name, value) {
+  metrics[name] = value;
+  return metrics[name];
+}
+
+export function resetMetrics() {
+  metrics.ticks = 0;
+  metrics.candles1mFormed = 0;
+  metrics.evalSymbols = 0;
+  metrics.candidates = 0;
+  metrics.emitted = 0;
+  metrics.rejectedBy = {};
+}
+
+export function onReject(rule) {
+  const key = String(rule || "unknown");
+  if (!metrics.rejectedBy[key]) {
+    metrics.rejectedBy[key] = 0;
+  }
+  metrics.rejectedBy[key] += 1;
+  return metrics.rejectedBy[key];
+}
+
+function snapshotMetrics() {
+  return {
+    ts: new Date().toISOString(),
+    ...metrics,
+    rejectedBy: { ...metrics.rejectedBy },
+  };
+}
+
+export function startMetricsReporter(options = {}) {
+  const { intervalMs = DEFAULT_INTERVAL_MS, logger = loggerFn } = options;
+  if (reporterStarted) return reporterTimer;
+  reporterStarted = true;
+  if (typeof logger === "function") {
+    loggerFn = logger;
+  }
+  reporterTimer = setInterval(() => {
+    try {
+      const snapshot = snapshotMetrics();
+      loggerFn(`[metrics] ${JSON.stringify(snapshot)}`);
+    } catch (err) {
+      console.error("[metrics] reporter error", err);
+    } finally {
+      metrics.ticks = 0;
+      metrics.candles1mFormed = 0;
+      metrics.evalSymbols = 0;
+      metrics.candidates = 0;
+      metrics.emitted = 0;
+      for (const key of Object.keys(metrics.rejectedBy)) {
+        metrics.rejectedBy[key] = 0;
+      }
+    }
+  }, intervalMs);
+  if (reporterTimer.unref) reporterTimer.unref();
+  return reporterTimer;
+}
+
+export function stopMetricsReporter() {
+  if (reporterTimer) {
+    clearInterval(reporterTimer);
+    reporterTimer = null;
+  }
+  reporterStarted = false;
+}

--- a/telegram.js
+++ b/telegram.js
@@ -16,8 +16,9 @@ if (token) {
 
 export function sendSignal(signal) {
   if (!bot || !chatId) {
-    console.warn("Telegram bot not configured properly.");
-    return;
+    const err = new Error("TELEGRAM_NOT_CONFIGURED");
+    err.code = "TELEGRAM_NOT_CONFIGURED";
+    return Promise.reject(err);
   }
 
   const data = signal.algoSignal || signal;
@@ -42,9 +43,7 @@ export function sendSignal(signal) {
     `📊 *Confidence Level:* ${confidence}\n\n` +
     `🕒 _Stay sharp. Market conditions may change quickly._`;
 
-  bot
-    .sendMessage(chatId, text, { parse_mode: "Markdown" })
-    .catch((err) => console.error("Telegram send error", err));
+  return bot.sendMessage(chatId, text, { parse_mode: "Markdown" });
 }
 
 export function sendNotification(message) {


### PR DESCRIPTION
## Summary
- add canonical token/symbol helpers plus a mapping loader that self-heals via the fallback fetcher
- refactor kite.js to load mappings before subscribing, guard tick ingestion, integrate the new aligner + metrics, and modernize session fetching
- introduce dedicated aligner/metrics/emitter modules, a backfill script, and observability docs while improving logger dedupe

## Testing
- NODE_ENV=test node --test --experimental-test-module-mocks tests/analyzeCandles.test.js
- NODE_ENV=test node --test --experimental-test-module-mocks tests/canPlaceTrade.test.js

------
https://chatgpt.com/codex/tasks/task_e_68c8c0cff3b083258b77c4226db3b8b1