### PR TITLE
Respect relaxed spread limits in risk validation

### DIFF
--- a/riskEngine.js
+++ b/riskEngine.js
@@ -481,6 +481,9 @@ export function isSignalValid(signal, ctx = {}) {
     timeSinceSignal: ctx.timeSinceSignal ?? 0,
     volume: signal.liquidity ?? ctx.volume,
     spread: signal.spread,
+    maxSpread: ctx.maxSpread,
+    maxSpreadPct: ctx.maxSpreadPct,
+    price: ctx.currentPrice ?? signal.entry,
     newsImpact: ctx.newsImpact,
     eventActive: ctx.eventActive,
   });

--- a/riskValidator.js
+++ b/riskValidator.js
@@ -156,13 +156,28 @@ export function checkMarketConditions({
   timeSinceSignal = 0,
   volume,
   spread,
+  maxSpread,
+  maxSpreadPct,
+  price,
   newsImpact = false,
   eventActive = false,
 }) {
   if (avgAtr && atr > avgAtr * 1.5) return false;
   if (indexTrend && signalDirection && indexTrend !== signalDirection) return false;
   if (timeSinceSignal > 2 * 60 * 1000) return false;
-  if (typeof spread === 'number' && spread > 0.3) return false;
+  if (typeof spread === 'number') {
+    let spreadLimit = 0.3;
+    if (typeof maxSpread === 'number') {
+      spreadLimit = maxSpread;
+    } else if (typeof maxSpreadPct === 'number') {
+      if (typeof price === 'number' && price > 0) {
+        spreadLimit = (maxSpreadPct / 100) * price;
+      } else {
+        spreadLimit = maxSpreadPct;
+      }
+    }
+    if (spread > spreadLimit) return false;
+  }
   if (typeof volume === 'number' && volume <= 0) return false;
   if (newsImpact || eventActive) return false;
   return true;

--- a/scanner.js
+++ b/scanner.js
@@ -257,6 +257,7 @@ export async function analyzeCandles(
       consolidationVolumeRatio: FILTERS.consolidationRatio,
       slippage,
       maxSlippage: FILTERS.maxSlippage,
+      maxSpread: FILTERS.maxSpread,
       maxSpreadPct: FILTERS.maxSpreadPct,
       minRR: RISK_REWARD_RATIO,
       minLiquidity: FILTERS.minLiquidity,


### PR DESCRIPTION
## Summary
- propagate the configured spread limits into the market condition checks so the relaxed mode thresholds are honored
- make the spread gate in `checkMarketConditions` use the provided limits instead of a hard-coded value

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ca0f93d2148325be4efd061aa2ae58