### PR TITLE
Add live feed monitor and guard duplicate starts

### DIFF
--- a/liveFeedMonitor.js
+++ b/liveFeedMonitor.js
@@ -1,0 +1,91 @@
+export function createLiveFeedMonitor({
+  isMarketOpen,
+  isLiveFeedRunning,
+  startLiveFeed,
+  logger = console,
+  intervalMs = 60_000,
+  setIntervalFn = setInterval,
+  clearIntervalFn = clearInterval,
+} = {}) {
+  if (typeof isMarketOpen !== "function") {
+    throw new TypeError("isMarketOpen must be a function");
+  }
+  if (typeof isLiveFeedRunning !== "function") {
+    throw new TypeError("isLiveFeedRunning must be a function");
+  }
+  if (typeof startLiveFeed !== "function") {
+    throw new TypeError("startLiveFeed must be a function");
+  }
+
+  let timer = null;
+  let lastOpenState = null;
+  let ioRef;
+
+  const log = (message) => {
+    if (!logger) return;
+    const fn =
+      typeof logger.log === "function"
+        ? logger.log
+        : typeof logger.info === "function"
+        ? logger.info
+        : null;
+    if (fn) {
+      fn.call(logger, message);
+    }
+  };
+
+  const evaluate = (io) => {
+    if (io !== undefined) {
+      ioRef = io;
+    }
+
+    const open = Boolean(isMarketOpen());
+
+    if (open) {
+      if (lastOpenState !== true) {
+        log("🔓 Market open detected; ensuring live feed is running.");
+      }
+      lastOpenState = true;
+
+      if (!isLiveFeedRunning()) {
+        log("🚀 Market open and live feed offline; starting automatically.");
+        if (ioRef) {
+          startLiveFeed(ioRef);
+        } else {
+          log("⚠️ No IO context available for live feed start.");
+        }
+      }
+    } else {
+      if (lastOpenState !== false) {
+        log("🛑 Market closed; live feed monitor standing by.");
+      }
+      lastOpenState = false;
+    }
+  };
+
+  const start = (io) => {
+    if (io !== undefined) {
+      ioRef = io;
+    }
+    if (timer) return timer;
+
+    timer = setIntervalFn(() => evaluate(), intervalMs);
+    timer.unref?.();
+    return timer;
+  };
+
+  const stop = () => {
+    if (!timer) return;
+    clearIntervalFn(timer);
+    timer = null;
+  };
+
+  const isRunning = () => timer !== null;
+
+  return {
+    start,
+    stop,
+    evaluate,
+    isRunning,
+  };
+}

--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -1,5 +1,5 @@
 import db from "../db.js";
-import { isMarketOpen, startLiveFeed, kc } from "../kite.js";
+import { isMarketOpen, startLiveFeed, kc, isLiveFeedRunning } from "../kite.js";
 import { logError } from "../logger.js";
 import { getIO } from "../sockets/io.js";
 
@@ -28,7 +28,11 @@ export const kiteRedirect = async (req, res) => {
         { upsert: true }
       );
 
-    if (isMarketOpen()) startLiveFeed(getIO());
+    if (isMarketOpen() && !isLiveFeedRunning()) {
+      startLiveFeed(getIO());
+    } else if (isMarketOpen()) {
+      console.log("ℹ️ Live feed already running; skipping duplicate start.");
+    }
     return res.send("✅ Login successful, session created.");
   } catch (err) {
     logError("kite redirect", err);

--- a/tests/liveFeedMonitor.test.js
+++ b/tests/liveFeedMonitor.test.js
@@ -1,0 +1,92 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createLiveFeedMonitor } from "../liveFeedMonitor.js";
+
+test("auto-starts live feed when market opens after being offline", () => {
+  let marketOpen = false;
+  let running = false;
+  const logs = [];
+  const ioContext = { foo: "bar" };
+  const startCalls = [];
+
+  const monitor = createLiveFeedMonitor({
+    isMarketOpen: () => marketOpen,
+    isLiveFeedRunning: () => running,
+    startLiveFeed: (ctx) => {
+      startCalls.push(ctx);
+      running = true;
+    },
+    logger: { log: (msg) => logs.push(msg) },
+  });
+
+  monitor.evaluate(ioContext);
+  assert.ok(
+    logs.some((msg) => msg.includes("Market closed")),
+    "should log closed state on initial evaluation"
+  );
+
+  logs.length = 0;
+  marketOpen = true;
+  running = false;
+  monitor.evaluate();
+  assert.equal(startCalls.length, 1, "should start feed when market opens");
+  assert.strictEqual(startCalls[0], ioContext, "should reuse last IO context");
+  assert.ok(
+    logs.some((msg) => msg.includes("starting automatically")),
+    "should log automatic start"
+  );
+
+  logs.length = 0;
+  monitor.evaluate();
+  assert.equal(
+    startCalls.length,
+    1,
+    "should not restart feed while it is reported running"
+  );
+
+  running = false;
+  monitor.evaluate();
+  assert.equal(startCalls.length, 2, "should restart when feed stops again");
+
+  marketOpen = false;
+  monitor.evaluate();
+  assert.ok(
+    logs.some((msg) => msg.includes("Market closed")),
+    "should log transition when market closes"
+  );
+
+  monitor.stop();
+});
+
+test("start/stop manage interval lifecycle", () => {
+  let scheduledFn;
+  const fakeTimer = { id: 1 };
+  let clearedCount = 0;
+
+  const monitor = createLiveFeedMonitor({
+    isMarketOpen: () => false,
+    isLiveFeedRunning: () => false,
+    startLiveFeed: () => {},
+    logger: null,
+    setIntervalFn: (fn, ms) => {
+      scheduledFn = fn;
+      assert.equal(ms, 60_000);
+      return fakeTimer;
+    },
+    clearIntervalFn: (handle) => {
+      assert.strictEqual(handle, fakeTimer);
+      clearedCount += 1;
+    },
+  });
+
+  monitor.start({});
+  assert.equal(typeof scheduledFn, "function", "should schedule interval callback");
+  assert.equal(monitor.isRunning(), true, "should report running state");
+
+  monitor.start({});
+  assert.equal(clearedCount, 0, "should not reschedule when already running");
+
+  monitor.stop();
+  assert.equal(monitor.isRunning(), false, "should clear running state on stop");
+  assert.equal(clearedCount, 1, "should clear interval handle exactly once");
+});


### PR DESCRIPTION
## Summary
- track Kite ticker lifecycle state and export an `isLiveFeedRunning` helper to prevent duplicate startups
- add a reusable live feed monitor that restarts the feed when markets are open and wire it into both the main server and modular startup paths with clean shutdown handling
- guard login-triggered feed starts and add unit coverage for the monitor helper

## Testing
- node --test tests/liveFeedMonitor.test.js
- npm test *(hangs after ~20 minutes; aborted with Ctrl+C)*

------
https://chatgpt.com/codex/tasks/task_e_68cd6b28702c8325ad9e5a6cc83fa374