### PR TITLE
Fix duplicate export of isLiveFeedRunning

### DIFF
--- a/kite.js
+++ b/kite.js
@@ -428,7 +428,7 @@ async function preloadStockData() {
   }
 }
 
-export function isLiveFeedRunning() {
+function isLiveFeedRunning() {
   if (liveFeedActive) return true;
   if (ticker && typeof ticker.connected === "function") {
     try {
@@ -1600,4 +1600,5 @@ export {
   resetInMemoryData,
   loadTickDataFromDB,
   lastTickTs,
+  isLiveFeedRunning,
 };


### PR DESCRIPTION
## Summary
- make `isLiveFeedRunning` a local helper and re-export it from the module export list to avoid duplicate named exports

## Testing
- npm test *(fails: hangs due to external MongoDB dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68cd924cb1fc8325b4138e5f4be37d19