### PR TITLE
Fix support/resistance lookup key

### DIFF
--- a/kite.js
+++ b/kite.js
@@ -1668,7 +1668,8 @@ export async function getHigherTimeframeData(symbol, timeframe = "15minute") {
 
 export async function getSupportResistanceLevels(symbol) {
   const token = await getTokenForSymbol(symbol);
-  const candles = (candleHistory[token] || []).filter(
+  const tokenStr = canonToken(token);
+  const candles = (candleHistory[tokenStr] || []).filter(
     (c) =>
       c &&
       typeof c.high === "number" &&


### PR DESCRIPTION
## Summary
- ensure support/resistance levels read candle history using canonical token keys

## Testing
- node --test --experimental-test-module-mocks tests/analyzeCandles.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d2f57093e08325896d490cb729892d