### PR TITLE
Adjust volatility check to use ATR percentage

### DIFF
--- a/kite.js
+++ b/kite.js
@@ -897,10 +897,18 @@ function intradayATR(candles, period = 14) {
   return sum / period;
 }
 
-function checkMarketVolatility(tokenStr, threshold = 5) {
+function checkMarketVolatility(
+  tokenStr,
+  thresholdPct = Number(process.env.ATR_PCT_THRESHOLD) || 0.6
+) {
   const candles = candleHistory[tokenStr] || [];
+  if (!candles.length) return true;
   const atr = intradayATR(candles, 14);
-  return atr <= threshold;
+  const lastCandle = candles[candles.length - 1];
+  const lastClose = lastCandle?.close || 0;
+  if (!lastClose) return true;
+  const atrPct = (atr / lastClose) * 100;
+  return atrPct <= thresholdPct;
 }
 
 async function checkRisk(signal) {


### PR DESCRIPTION
## Summary
- update `checkMarketVolatility` to compare ATR as a percentage of the latest close instead of an absolute rupee value
- allow the ATR percentage threshold to be configured through `ATR_PCT_THRESHOLD` with a 0.6% default
- guard against missing candle history or close values so high-priced instruments are not unnecessarily filtered

## Testing
- npm test *(hangs after reported successes due to existing open handles; interrupted manually)*

------
https://chatgpt.com/codex/tasks/task_e_68d2fbbe7e44832581e03d707fc1d1e1