### PR TITLE
Use passed candle series for session data

### DIFF
--- a/scanner.js
+++ b/scanner.js
@@ -17,7 +17,6 @@ import {
   getHistoricalData,
   getTokenForSymbol,
 } from "./kite.js";
-import { candleHistory } from "./dataEngine.js";
 import { evaluateAllStrategies } from "./strategyEngine.js";
 import { evaluateStrategies } from "./strategies.js";
 import { RISK_REWARD_RATIO, calculatePositionSize } from "./positionSizing.js";
@@ -124,7 +123,7 @@ export async function analyzeCandles(
 
     const token = await getTokenForSymbol(symbol);
     const dailyHistory = await getHistoricalData(token);
-    const sessionData = candleHistory[token] || validCandles;
+    const sessionData = candles;
 
     const context = {
       symbol,


### PR DESCRIPTION
## Summary
- stop importing candleHistory into the scanner and relying on the dataEngine cache
- use the candles array passed to analyzeCandles for session-level strategy evaluation

## Testing
- npm test (terminated after suite completed because the process kept open handles)


------
https://chatgpt.com/codex/tasks/task_e_68d2fce31b948325a63480dc7efbd6eb