### PR TITLE
Ensure scanner falls back to raw strategies when regime filter empty

### DIFF
--- a/scanner.js
+++ b/scanner.js
@@ -199,8 +199,9 @@ export async function analyzeCandles(
       topN: 1,
     });
     const filtered = filterStrategiesByRegime(stratResults, marketContext);
-    const [base] = filtered;
-    if (!base) return null;
+    const basePick = (filtered.length ? filtered : stratResults)[0];
+    if (!basePick) return null;
+    const base = { ...basePick };
 
     if (altStrategies && altStrategies[0]) {
       base.strategy = altStrategies[0].name;


### PR DESCRIPTION
## Summary
- ensure the scanner falls back to the original strategy results when the regime filter yields no entries
- copy the chosen strategy result before applying alternative strategy overrides

## Testing
- npm test *(terminated manually after tests logged success due to hang)*

------
https://chatgpt.com/codex/tasks/task_e_68d364f12a98832592a06a7f21a1fdf6