### PR TITLE
Ensure historical data lookup uses string token

### DIFF
--- a/scanner.js
+++ b/scanner.js
@@ -121,8 +121,9 @@ export async function analyzeCandles(
     const features = computeFeatures(validCandles);
     if (!features) return null;
 
-    const token = await getTokenForSymbol(symbol);
-    const dailyHistory = await getHistoricalData(token);
+    const tokenNum = await getTokenForSymbol(symbol);
+    const tokenStr = String(tokenNum);
+    const dailyHistory = await getHistoricalData(tokenStr);
     const sessionData = candles;
 
     const context = {


### PR DESCRIPTION
## Summary
- convert the instrument token returned by `getTokenForSymbol` to a string before fetching historical data so the lookup matches store keys

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d365e37134832584afa6d633d1019e