### PR TITLE
Improve health diagnostics and portfolio gate logging

### DIFF
--- a/src/controllers/health.controller.js
+++ b/src/controllers/health.controller.js
@@ -1,13 +1,22 @@
 import db from "../db.js";
-import { isMarketOpen, kc, tickBuffer, lastTickTs } from "../kite.js";
+import {
+  isMarketOpen,
+  kc,
+  tickBuffer,
+  lastTickTs,
+  getInstrumentTokenCount,
+} from "../kite.js";
 
 export const getHealth = async (req, res) => {
   const doc = await db.collection("stock_symbols").findOne({});
+  const subscribedCount = Object.keys(tickBuffer).length;
+  const instrumentTokenCount = getInstrumentTokenCount();
   res.json({
     session: Boolean(kc._access_token),
     marketOpen: isMarketOpen(),
     universeCount: doc?.symbols?.length || 0,
-    subscribedCount: Object.keys(tickBuffer).length,
+    subscribedCount,
+    instrumentTokenCount,
     lastTickTs,
   });
 };


### PR DESCRIPTION
## Summary
- make the kite resetDatabase helper return a structured summary instead of using an Express response
- expose instrument token counts in the health endpoint to compare tick buffer activity vs actual subscriptions
- add optional DEBUG_PORTFOLIO logging around the gating checks to highlight which rule blocked a signal

## Testing
- npm test *(fails: analyzeCandles returns a signal for valid data)*

------
https://chatgpt.com/codex/tasks/task_e_68d36819524c8325895799d94a946ac5