### PR TITLE
Improve spread validation and volatility threshold

### DIFF
--- a/kite.js
+++ b/kite.js
@@ -933,7 +933,7 @@ function intradayATR(candles, period = 14) {
 
 function checkMarketVolatility(
   tokenStr,
-  thresholdPct = Number(process.env.ATR_PCT_THRESHOLD) || 0.6
+  thresholdPct = Number(process.env.ATR_PCT_THRESHOLD) || 2.0
 ) {
   const candles = candleHistory[tokenStr] || [];
   if (!candles.length) return true;

--- a/riskEngine.js
+++ b/riskEngine.js
@@ -473,6 +473,8 @@ export function isSignalValid(signal, ctx = {}) {
       maxSlippage: ctx.maxSlippage,
       spread: signal.spread,
       maxSpreadPct: ctx.maxSpreadPct,
+      maxSpread: ctx.maxSpread,
+      price: ctx.currentPrice ?? signal.entry,
     })
   )
     return false;

--- a/riskValidator.js
+++ b/riskValidator.js
@@ -114,6 +114,8 @@ export function validateVolatilitySlippage({
   maxSlippage,
   spread,
   maxSpreadPct,
+  price,
+  maxSpread,
 }) {
   if (typeof minATR === 'number' && typeof atr === 'number' && atr < minATR)
     return false;
@@ -139,12 +141,22 @@ export function validateVolatilitySlippage({
     slippage > maxSlippage
   )
     return false;
-  if (
-    typeof spread === 'number' &&
-    typeof maxSpreadPct === 'number' &&
-    spread > maxSpreadPct
-  )
-    return false;
+  {
+    // Spread limit handling (supports absolute or percentage thresholds)
+    let spreadLimit = null;
+    if (typeof maxSpread === 'number') {
+      spreadLimit = maxSpread;
+    } else if (typeof maxSpreadPct === 'number') {
+      if (typeof price === 'number' && price > 0) {
+        spreadLimit = (maxSpreadPct / 100) * price;
+      } else {
+        // Fallback: interpret maxSpreadPct as an absolute if price is unavailable
+        spreadLimit = maxSpreadPct;
+      }
+    }
+    if (typeof spread === 'number' && spreadLimit !== null && spread > spreadLimit)
+      return false;
+  }
   return true;
 }
 


### PR DESCRIPTION
## Summary
- allow `validateVolatilitySlippage` to cap spreads using either absolute or percentage thresholds with optional price context
- pass current price and absolute spread limits from the risk engine into the validator for consistent enforcement
- relax the default intraday ATR percentage threshold used by kite market volatility checks

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68d825b28a348325a83cfcdbd2a01321