### PR TITLE
Improve risk debugging and momentum filters

### DIFF
--- a/riskEngine.js
+++ b/riskEngine.js
@@ -14,6 +14,8 @@ import { calculateStdDev, calculateZScore } from "./util.js";
 import { resolveSignalConflicts } from "./portfolioContext.js";
 import { riskDefaults } from "./riskConfig.js";
 
+const riskDebug = process.env.RISK_DEBUG === "true";
+
 function getWeekNumber(d = new Date()) {
   const oneJan = new Date(d.getFullYear(), 0, 1);
   return Math.floor((d - oneJan) / (7 * 24 * 60 * 60 * 1000));
@@ -133,6 +135,26 @@ export function isSignalValid(signal, ctx = {}) {
   const today = new Date().getDate();
   const week = getWeekNumber();
   const month = new Date().getMonth();
+  const debugTrace = Array.isArray(ctx.debugTrace) ? ctx.debugTrace : null;
+  const symbol = signal.stock || signal.symbol || "UNKNOWN";
+  const recordRejection = (code, details = {}) => {
+    if (debugTrace) {
+      debugTrace.push(
+        Object.keys(details).length ? { code, details } : { code }
+      );
+    }
+    if (riskDebug) {
+      try {
+        const info = Object.keys(details).length
+          ? ` ${JSON.stringify(details)}`
+          : "";
+        console.log(`[RISK][${symbol}] ${code}${info}`);
+      } catch (err) {
+        console.log(`[RISK][${symbol}] ${code}`);
+      }
+    }
+    return false;
+  };
   if (riskState.lastResetDay !== today) resetRiskState();
   if (riskState.lastResetWeek !== week) {
     riskState.weeklyLoss = 0;
@@ -144,7 +166,7 @@ export function isSignalValid(signal, ctx = {}) {
   }
 
   riskState.signalCount += 1;
-  if (riskState.systemPaused) return false;
+  if (riskState.systemPaused) return recordRejection("systemPaused");
   const bucketMs = ctx.timeBucketMs || 60 * 1000;
   const bucket = Math.floor(now / bucketMs);
   const count = riskState.timeBuckets.get(bucket) || 0;
@@ -152,7 +174,9 @@ export function isSignalValid(signal, ctx = {}) {
     typeof ctx.maxSimultaneousSignals === "number" &&
     count >= ctx.maxSimultaneousSignals
   )
-    return false;
+    return recordRejection("tooManySimultaneousSignals", {
+      max: ctx.maxSimultaneousSignals,
+    });
   riskState.timeBuckets.set(bucket, count + 1);
   if (riskState.timeBuckets.size > 10) {
     for (const [k] of riskState.timeBuckets) {
@@ -160,7 +184,11 @@ export function isSignalValid(signal, ctx = {}) {
     }
   }
   const maxSignals = ctx.maxSignalsPerDay ?? riskState.maxSignalsPerDay;
-  if (riskState.signalCount > maxSignals) return false;
+  if (riskState.signalCount > maxSignals)
+    return recordRejection("maxSignalsPerDay", {
+      max: maxSignals,
+      count: riskState.signalCount,
+    });
   if (
     typeof ctx.highVolatilityThresh === "number" &&
     typeof ctx.volatility === "number" &&
@@ -168,14 +196,22 @@ export function isSignalValid(signal, ctx = {}) {
   ) {
     const interval =
       (ctx.throttleMs ?? riskState.volatilityThrottleMs) || 60000;
-    if (now - riskState.lastTradeTime < interval) return false;
+    if (now - riskState.lastTradeTime < interval)
+      return recordRejection("volatilityThrottle", {
+        interval,
+        lastTradeTime: riskState.lastTradeTime,
+      });
   }
   if (
     typeof ctx.signalFloodThreshold === "number" &&
     riskState.signalCount > ctx.signalFloodThreshold
   ) {
     const interval = ctx.signalFloodThrottleMs || 60000;
-    if (now - riskState.lastTradeTime < interval) return false;
+    if (now - riskState.lastTradeTime < interval)
+      return recordRejection("signalFloodThrottle", {
+        interval,
+        lastTradeTime: riskState.lastTradeTime,
+      });
   }
 
   if (
@@ -183,37 +219,65 @@ export function isSignalValid(signal, ctx = {}) {
     typeof ctx.maxIndexVolatility === "number" &&
     ctx.indexVolatility > ctx.maxIndexVolatility
   )
-    return false;
+    return recordRejection("indexVolatility", {
+      max: ctx.maxIndexVolatility,
+      value: ctx.indexVolatility,
+    });
   if (
     typeof ctx.vwapParticipation === "number" &&
     typeof ctx.minVwapParticipation === "number" &&
     ctx.vwapParticipation < ctx.minVwapParticipation
   )
-    return false;
-  if (ctx.negativeNews) return false;
+    return recordRejection("vwapParticipation", {
+      min: ctx.minVwapParticipation,
+      value: ctx.vwapParticipation,
+    });
+  if (ctx.negativeNews) return recordRejection("negativeNews");
   if (
     ctx.maxSignalAgeMinutes &&
     signal.generatedAt &&
     now - new Date(signal.generatedAt).getTime() >
       ctx.maxSignalAgeMinutes * 60 * 1000
   )
-    return false;
+    return recordRejection("signalTooOld", {
+      maxMinutes: ctx.maxSignalAgeMinutes,
+    });
 
   const maxLoss = ctx.maxDailyLoss ?? riskState.maxDailyLoss;
-  if (riskState.dailyLoss >= maxLoss) return false;
+  if (riskState.dailyLoss >= maxLoss)
+    return recordRejection("maxDailyLoss", {
+      loss: riskState.dailyLoss,
+      max: maxLoss,
+    });
   const maxLossPct = ctx.maxDailyLossPct ?? riskState.maxDailyLossPct;
   if (
     maxLossPct > 0 &&
     riskState.equityPeak > 0 &&
     riskState.dailyLoss / riskState.equityPeak >= maxLossPct
   )
-    return false;
+    return recordRejection("maxDailyLossPct", {
+      loss: riskState.dailyLoss,
+      peak: riskState.equityPeak,
+      maxPct: maxLossPct,
+    });
   const maxCum = ctx.maxCumulativeLoss ?? riskState.maxCumulativeLoss;
-  if (maxCum > 0 && riskState.dailyLoss >= maxCum) return false;
+  if (maxCum > 0 && riskState.dailyLoss >= maxCum)
+    return recordRejection("maxCumulativeLoss", {
+      loss: riskState.dailyLoss,
+      max: maxCum,
+    });
   const maxWeekly = ctx.maxWeeklyDrawdown ?? riskState.maxWeeklyDrawdown;
-  if (maxWeekly > 0 && riskState.weeklyLoss >= maxWeekly) return false;
+  if (maxWeekly > 0 && riskState.weeklyLoss >= maxWeekly)
+    return recordRejection("maxWeeklyDrawdown", {
+      loss: riskState.weeklyLoss,
+      max: maxWeekly,
+    });
   const maxMonthly = ctx.maxMonthlyDrawdown ?? riskState.maxMonthlyDrawdown;
-  if (maxMonthly > 0 && riskState.monthlyLoss >= maxMonthly) return false;
+  if (maxMonthly > 0 && riskState.monthlyLoss >= maxMonthly)
+    return recordRejection("maxMonthlyDrawdown", {
+      loss: riskState.monthlyLoss,
+      max: maxMonthly,
+    });
   const drawdownLimit =
     ctx.equityDrawdownLimitPct ?? riskState.equityDrawdownLimitPct;
   if (
@@ -221,28 +285,54 @@ export function isSignalValid(signal, ctx = {}) {
     riskState.equityPeak > 0 &&
     riskState.equity < riskState.equityPeak * (1 - drawdownLimit)
   )
-    return false;
+    return recordRejection("equityDrawdown", {
+      equity: riskState.equity,
+      peak: riskState.equityPeak,
+      limitPct: drawdownLimit,
+    });
   const maxRisk = ctx.maxDailyRisk ?? riskState.maxDailyRisk;
-  if (riskState.dailyRisk >= maxRisk) return false;
+  if (riskState.dailyRisk >= maxRisk)
+    return recordRejection("maxDailyRisk", {
+      risk: riskState.dailyRisk,
+      max: maxRisk,
+    });
   const maxTrades = ctx.maxTradesPerDay ?? riskState.maxTradesPerDay;
-  if (riskState.tradeCount >= maxTrades) return false;
+  if (riskState.tradeCount >= maxTrades)
+    return recordRejection("maxTradesPerDay", {
+      trades: riskState.tradeCount,
+      max: maxTrades,
+    });
   const maxStreak = ctx.maxLossStreak ?? riskState.maxLossStreak;
-  if (riskState.consecutiveLosses >= maxStreak) return false;
-  if (ctx.cooloffAfterLoss && riskState.lastTradeWasLoss) return false;
+  if (riskState.consecutiveLosses >= maxStreak)
+    return recordRejection("maxLossStreak", {
+      losses: riskState.consecutiveLosses,
+      max: maxStreak,
+    });
+  if (ctx.cooloffAfterLoss && riskState.lastTradeWasLoss)
+    return recordRejection("cooloffAfterLoss");
   if (
     typeof ctx.maxOpenPositions === "number" &&
     typeof ctx.openPositionsCount === "number" &&
     ctx.openPositionsCount >= ctx.maxOpenPositions
   )
-    return false;
+    return recordRejection("maxOpenPositions", {
+      count: ctx.openPositionsCount,
+      max: ctx.maxOpenPositions,
+    });
   if (ctx.preventOverlap && Array.isArray(ctx.openSymbols)) {
-    if (ctx.openSymbols.includes(signal.stock || signal.symbol)) return false;
+    if (ctx.openSymbols.includes(signal.stock || signal.symbol))
+      return recordRejection("preventOverlap", {
+        symbol: signal.stock || signal.symbol,
+      });
   }
   const dir = signal.direction === "Long" ? "long" : "short";
   if (ctx.openPositionsMap instanceof Map) {
     const existing = ctx.openPositionsMap.get(signal.stock || signal.symbol);
     if (existing && existing.side && existing.side.toLowerCase() !== dir)
-      return false;
+      return recordRejection("positionConflict", {
+        existing: existing.side,
+        requested: dir,
+      });
   }
   if (
     ctx.resolveConflicts &&
@@ -252,46 +342,68 @@ export function isSignalValid(signal, ctx = {}) {
       strategy: signal.algoSignal?.strategy || signal.pattern,
     })
   )
-    return false;
+    return recordRejection("resolveConflictBlocked");
 
   const inst = signal.stock || signal.symbol;
-  if (ctx.blockWatchlist && riskState.watchList.has(inst)) return false;
+  if (ctx.blockWatchlist && riskState.watchList.has(inst))
+    return recordRejection("watchlistBlocked");
   const stratKey = `${inst}-${signal.algoSignal?.strategy || signal.pattern}`;
   if (
     ctx.strategyFailWindowMs &&
     riskState.strategyFailMap.has(stratKey) &&
     now - riskState.strategyFailMap.get(stratKey) < ctx.strategyFailWindowMs
   )
-    return false;
+    return recordRejection("strategyCooldown", {
+      lastFailure: riskState.strategyFailMap.get(stratKey),
+      windowMs: ctx.strategyFailWindowMs,
+    });
   const instCount = riskState.tradesPerInstrument.get(inst) || 0;
   const maxPerInst =
     ctx.maxTradesPerInstrument ?? riskState.maxTradesPerInstrument;
-  if (instCount >= maxPerInst) return false;
+  if (instCount >= maxPerInst)
+    return recordRejection("maxTradesPerInstrument", {
+      count: instCount,
+      max: maxPerInst,
+    });
 
   const sec = signal.sector || "GEN";
   const secCount = riskState.tradesPerSector.get(sec) || 0;
   const maxPerSec = ctx.maxTradesPerSector ?? riskState.maxTradesPerSector;
-  if (secCount >= maxPerSec) return false;
+  if (secCount >= maxPerSec)
+    return recordRejection("maxTradesPerSector", {
+      count: secCount,
+      max: maxPerSec,
+    });
 
   if (
     typeof ctx.minTradeValue === "number" &&
     typeof ctx.tradeValue === "number" &&
     ctx.tradeValue < ctx.minTradeValue
   )
-    return false;
+    return recordRejection("minTradeValue", {
+      min: ctx.minTradeValue,
+      value: ctx.tradeValue,
+    });
   if (
     typeof ctx.maxTradeValue === "number" &&
     typeof ctx.tradeValue === "number" &&
     ctx.tradeValue > ctx.maxTradeValue
   )
-    return false;
+    return recordRejection("maxTradeValue", {
+      max: ctx.maxTradeValue,
+      value: ctx.tradeValue,
+    });
   if (
     typeof ctx.volatilityFilter === "number" &&
     typeof signal.atr === "number" &&
     signal.atr > ctx.volatilityFilter
   )
-    return false;
-  if (ctx.allowPyramiding === false && ctx.hasPositionForSymbol) return false;
+    return recordRejection("volatilityFilter", {
+      atr: signal.atr,
+      max: ctx.volatilityFilter,
+    });
+  if (ctx.allowPyramiding === false && ctx.hasPositionForSymbol)
+    return recordRejection("pyramidingDisabled");
 
   const conf = signal.confidence ?? signal.confidenceScore ?? 0;
   const aiOverride =
@@ -303,7 +415,10 @@ export function isSignalValid(signal, ctx = {}) {
     conf < ctx.minConfidence &&
     !aiOverride
   )
-    return false;
+    return recordRejection("minConfidence", {
+      min: ctx.minConfidence,
+      confidence: conf,
+    });
   if (ctx.entryStdDev === undefined && Array.isArray(ctx.prices)) {
     ctx.entryStdDev = calculateStdDev(
       ctx.prices,
@@ -321,46 +436,75 @@ export function isSignalValid(signal, ctx = {}) {
     typeof ctx.mlConfidence === "number" &&
     ctx.mlConfidence < ctx.minMlConfidence
   )
-    return false;
+    return recordRejection("minMlConfidence", {
+      min: ctx.minMlConfidence,
+      value: ctx.mlConfidence,
+    });
   if (
     typeof ctx.minBacktestWinRate === "number" &&
     typeof ctx.backtestWinRate === "number" &&
     ctx.backtestWinRate < ctx.minBacktestWinRate
   )
-    return false;
+    return recordRejection("minBacktestWinRate", {
+      min: ctx.minBacktestWinRate,
+      value: ctx.backtestWinRate,
+    });
   if (
     typeof ctx.minRecentAccuracy === "number" &&
     typeof ctx.recentAccuracy === "number" &&
     ctx.recentAccuracy < ctx.minRecentAccuracy
   )
-    return false;
+    return recordRejection("minRecentAccuracy", {
+      min: ctx.minRecentAccuracy,
+      value: ctx.recentAccuracy,
+    });
   if (
     typeof ctx.maxEntryStdDev === "number" &&
     typeof ctx.entryStdDev === "number" &&
     ctx.entryStdDev > ctx.maxEntryStdDev
   )
-    return false;
+    return recordRejection("maxEntryStdDev", {
+      max: ctx.maxEntryStdDev,
+      value: ctx.entryStdDev,
+    });
   if (
     typeof ctx.minZScoreAbs === "number" &&
     typeof ctx.zScore === "number" &&
     Math.abs(ctx.zScore) < ctx.minZScoreAbs
   )
-    return false;
+    return recordRejection("minZScoreAbs", {
+      min: ctx.minZScoreAbs,
+      value: ctx.zScore,
+    });
   if (
     typeof ctx.maxRiskScore === "number" &&
     typeof signal.riskScore === "number" &&
     signal.riskScore > ctx.maxRiskScore
   )
-    return false;
+    return recordRejection("maxRiskScore", {
+      max: ctx.maxRiskScore,
+      value: signal.riskScore,
+    });
 
   const upper = signal.upperCircuit ?? ctx.upperCircuit;
   const lower = signal.lowerCircuit ?? ctx.lowerCircuit;
-  if (typeof upper === "number" && signal.entry >= upper * 0.99) return false;
-  if (typeof lower === "number" && signal.entry <= lower * 1.01) return false;
-  if (signal.inGapZone || ctx.inGapZone) return false;
+  if (typeof upper === "number" && signal.entry >= upper * 0.99)
+    return recordRejection("nearUpperCircuit", {
+      entry: signal.entry,
+      upper,
+    });
+  if (typeof lower === "number" && signal.entry <= lower * 1.01)
+    return recordRejection("nearLowerCircuit", {
+      entry: signal.entry,
+      lower,
+    });
+  if (signal.inGapZone || ctx.inGapZone)
+    return recordRejection("gapZone", { gapZone: true });
 
   if (signal.expiresAt && now > new Date(signal.expiresAt).getTime())
-    return false;
+    return recordRejection("signalExpired", {
+      expiresAt: signal.expiresAt,
+    });
 
   const rr = validateRR({
     strategy: signal.algoSignal?.strategy || signal.pattern,
@@ -369,15 +513,24 @@ export function isSignalValid(signal, ctx = {}) {
     target: signal.target2 ?? signal.target,
     winrate: ctx.winrate || 0,
   });
-  if (!rr.valid) return false;
+  if (!rr.valid)
+    return recordRejection("rrBelowMinimum", {
+      rr: rr.rr,
+      min: rr.minRR,
+    });
   const minRR = ctx.minRR ?? 2;
-  if (rr.rr < minRR) return false;
+  if (rr.rr < minRR)
+    return recordRejection("rrBelowThreshold", { rr: rr.rr, minRR });
 
   if (
     signal.atr &&
     Math.abs(signal.entry - signal.stopLoss) > (ctx.maxSLATR ?? 2) * signal.atr
   )
-    return false;
+    return recordRejection("slAtrTooWide", {
+      atr: signal.atr,
+      slDistance: Math.abs(signal.entry - signal.stopLoss),
+      maxMultiplier: ctx.maxSLATR ?? 2,
+    });
 
   if (
     !validateATRStopLoss({
@@ -386,7 +539,7 @@ export function isSignalValid(signal, ctx = {}) {
       atr: signal.atr,
     })
   )
-    return false;
+    return recordRejection("atrStopLossInvalid");
 
   if (
     isSLInvalid({
@@ -396,7 +549,10 @@ export function isSignalValid(signal, ctx = {}) {
       structureBreak: ctx.structureBreak,
     })
   )
-    return false;
+    return recordRejection("slInvalid", {
+      price: ctx.currentPrice ?? signal.entry,
+      stopLoss: signal.stopLoss,
+    });
 
   if (
     !validateSupportResistance({
@@ -407,7 +563,10 @@ export function isSignalValid(signal, ctx = {}) {
       atr: signal.atr,
     })
   )
-    return false;
+    return recordRejection("supportResistanceFail", {
+      support: signal.support,
+      resistance: signal.resistance,
+    });
 
   if (
     !validateVolumeSpike({
@@ -415,40 +574,60 @@ export function isSignalValid(signal, ctx = {}) {
       avgVolume: ctx.avgVolume,
     })
   )
-    return false;
+    return recordRejection("volumeSpikeFail", {
+      volume: signal.volume ?? ctx.volume,
+      avgVolume: ctx.avgVolume,
+    });
   if (
     ctx.requireMomentum &&
     typeof ctx.rsi === "number" &&
     ((signal.direction === "Long" && ctx.rsi < (ctx.minRsi ?? 55)) ||
       (signal.direction === "Short" && ctx.rsi > (ctx.maxRsi ?? 45)))
   )
-    return false;
+    return recordRejection("momentumRsi", {
+      rsi: ctx.rsi,
+      minRsi: ctx.minRsi ?? 55,
+      maxRsi: ctx.maxRsi ?? 45,
+      direction: signal.direction,
+    });
   if (
     ctx.requireMomentum &&
     typeof ctx.adx === "number" &&
     ctx.adx < (ctx.minAdx ?? 20)
   )
-    return false;
+    return recordRejection("momentumAdx", {
+      adx: ctx.adx,
+      minAdx: ctx.minAdx ?? 20,
+    });
   if (
     typeof ctx.minRvol === "number" &&
     typeof (signal.rvol ?? ctx.rvol) === "number" &&
     (signal.rvol ?? ctx.rvol) < ctx.minRvol
   )
-    return false;
+    return recordRejection("minRvol", {
+      rvol: signal.rvol ?? ctx.rvol,
+      minRvol: ctx.minRvol,
+    });
 
   if (
     typeof ctx.minLiquidity === "number" &&
     typeof (signal.liquidity ?? ctx.volume) === "number" &&
     (signal.liquidity ?? ctx.volume) < ctx.minLiquidity
   )
-    return false;
+    return recordRejection("minLiquidity", {
+      liquidity: signal.liquidity ?? ctx.volume,
+      minLiquidity: ctx.minLiquidity,
+    });
 
   if (
     typeof ctx.minVolume === "number" &&
     typeof (signal.liquidity ?? ctx.volume) === "number" &&
     (signal.liquidity ?? ctx.volume) < ctx.minVolume
   )
-    return false;
+    return recordRejection("minVolume", {
+      volume: signal.liquidity ?? ctx.volume,
+      minVolume: ctx.minVolume,
+    });
 
   if (
     typeof ctx.minVolumeRatio === "number" &&
@@ -456,7 +635,11 @@ export function isSignalValid(signal, ctx = {}) {
     typeof (signal.liquidity ?? ctx.volume) === "number" &&
     (signal.liquidity ?? ctx.volume) < ctx.avgVolume * ctx.minVolumeRatio
   )
-    return false;
+    return recordRejection("minVolumeRatio", {
+      volume: signal.liquidity ?? ctx.volume,
+      avgVolume: ctx.avgVolume,
+      ratio: ctx.minVolumeRatio,
+    });
 
   if (
     !validateVolatilitySlippage({
@@ -477,28 +660,57 @@ export function isSignalValid(signal, ctx = {}) {
       price: ctx.currentPrice ?? signal.entry,
     })
   )
-    return false;
+    return recordRejection("volatilitySlippage", {
+      atr: signal.atr,
+      minATR: ctx.minVolatility,
+      maxATR: ctx.maxVolatility,
+      dailyRangePct: ctx.dailyRangePct,
+      wickPct: ctx.wickPct,
+      slippage: ctx.slippage,
+      spread: signal.spread,
+      maxSpreadPct: ctx.maxSpreadPct,
+      maxSpread: ctx.maxSpread,
+    });
 
-  if (typeof ctx.minATR === "number" && signal.atr < ctx.minATR) return false;
-  if (typeof ctx.maxATR === "number" && signal.atr > ctx.maxATR) return false;
+  if (typeof ctx.minATR === "number" && signal.atr < ctx.minATR)
+    return recordRejection("minAtr", {
+      atr: signal.atr,
+      minATR: ctx.minATR,
+    });
+  if (typeof ctx.maxATR === "number" && signal.atr > ctx.maxATR)
+    return recordRejection("maxAtr", {
+      atr: signal.atr,
+      maxATR: ctx.maxATR,
+    });
 
   if (
     typeof ctx.minSLDistancePct === "number" &&
     Math.abs(signal.entry - signal.stopLoss) / signal.entry <
       ctx.minSLDistancePct
   )
-    return false;
+    return recordRejection("minSlDistancePct", {
+      distancePct: Math.abs(signal.entry - signal.stopLoss) / signal.entry,
+      minPct: ctx.minSLDistancePct,
+    });
 
   const slDist = Math.abs(signal.entry - signal.stopLoss);
   const lossPct = slDist / signal.entry;
   const maxPerTrade = ctx.maxLossPerTradePct ?? riskState.maxLossPerTradePct;
-  if (maxPerTrade > 0 && lossPct > maxPerTrade) return false;
+  if (maxPerTrade > 0 && lossPct > maxPerTrade)
+    return recordRejection("maxLossPerTradePct", {
+      lossPct,
+      maxPct: maxPerTrade,
+    });
   if (
     typeof signal.spread === "number" &&
     slDist > 0 &&
     signal.spread / slDist > (ctx.maxSpreadSLRatio ?? 0.3)
   )
-    return false;
+    return recordRejection("spreadVsSl", {
+      spread: signal.spread,
+      slDist,
+      maxRatio: ctx.maxSpreadSLRatio ?? 0.3,
+    });
 
   const marketOk = checkMarketConditions({
     atr: signal.atr,
@@ -514,7 +726,7 @@ export function isSignalValid(signal, ctx = {}) {
     newsImpact: ctx.newsImpact,
     eventActive: ctx.eventActive,
   });
-  if (!marketOk) return false;
+  if (!marketOk) return recordRejection("marketConditions");
 
   const timingOk = checkTimingFilters({
     now: ctx.now,
@@ -528,7 +740,7 @@ export function isSignalValid(signal, ctx = {}) {
     indexRebalanceDays: ctx.indexRebalanceDays,
     expiryDates: ctx.expiryDates,
   });
-  if (!timingOk) return false;
+  if (!timingOk) return recordRejection("timingFilters");
 
   const key = `${signal.stock || signal.symbol}-${signal.direction}-${
     signal.pattern || signal.algoSignal?.strategy
@@ -538,14 +750,14 @@ export function isSignalValid(signal, ctx = {}) {
     riskState.duplicateMap.has(key) &&
     now - riskState.duplicateMap.get(key) < dupWindow
   )
-    return false;
+    return recordRejection("duplicateSignal", { windowMs: dupWindow });
   riskState.duplicateMap.set(key, now);
 
   if (ctx.marketRegime) {
     if (ctx.marketRegime === "bullish" && signal.direction === "Short")
-      return false;
+      return recordRejection("bullishRegimeShort");
     if (ctx.marketRegime === "bearish" && signal.direction === "Long")
-      return false;
+      return recordRejection("bearishRegimeLong");
   }
 
   const group = signal.correlationGroup || signal.sector;
@@ -555,7 +767,10 @@ export function isSignalValid(signal, ctx = {}) {
       riskState.correlationMap.has(group) &&
       now - riskState.correlationMap.get(group) < corrWindow
     )
-      return false;
+      return recordRejection("correlationThrottle", {
+        group,
+        windowMs: corrWindow,
+      });
     riskState.correlationMap.set(group, now);
   }
 


### PR DESCRIPTION
## Summary
- add detailed rejection tracing in the risk engine to surface blocking criteria when RISK_DEBUG is enabled
- relax the scanner momentum filter and feed dynamic RSI/ADX/RVOL thresholds into risk validation
- log consolidated rejection reasons and lower the minimum volume ratio to widen candidate coverage

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da1abd69288325946a8e73f19d661a