### PR TITLE
Improve candle cache normalization and history cap handling

### DIFF
--- a/candleCache.js
+++ b/candleCache.js
@@ -1,8 +1,41 @@
+// candleCache.js
 import db from "./db.js";
 
 export const candleHistory = {};
 const loaders = {};
-const MAX_CANDLES = 300;
+
+// One cap to rule them all (import this in other files)
+export const HISTORY_CAP = Number(process.env.HISTORY_CAP) || 300;
+
+function toDateSafe(v) {
+  if (v instanceof Date) return v;
+  const d = new Date(v);
+  if (!Number.isNaN(+d)) return d;
+  // fallback for strings like "YYYY-MM-DDTHH:MM:00"
+  if (typeof v === "string" && /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/.test(v)) {
+    const d2 = new Date(v.replace(" ", "T"));
+    if (!Number.isNaN(+d2)) return d2;
+  }
+  return new Date(); // last resort (shouldn't happen often)
+}
+
+function minuteKey(ts) {
+  const d = new Date(toDateSafe(ts));
+  d.setSeconds(0, 0);
+  return d.getTime();
+}
+
+function normalizeCandle(c) {
+  const ts = c.timestamp ?? c.date ?? c.ts ?? c.minute ?? Date.now();
+  return {
+    open: Number(c.open),
+    high: Number(c.high),
+    low: Number(c.low),
+    close: Number(c.close),
+    volume: Number(c.volume) || 0,
+    timestamp: toDateSafe(ts),
+  };
+}
 
 export function getCandleHistory(token) {
   return candleHistory[String(token)] || [];
@@ -18,16 +51,20 @@ export async function ensureCandleHistory(token) {
       const doc = await db
         .collection("historical_session_data")
         .findOne({ token: Number(tokenStr) });
-      const data = doc?.candles || doc?.data || [];
-      candleHistory[tokenStr] = data.map((c) => ({
-        open: c.open,
-        high: c.high,
-        low: c.low,
-        close: c.close,
-        volume: c.volume,
-        timestamp: new Date(c.date),
-      }));
-      candleHistory[tokenStr] = candleHistory[tokenStr].slice(-MAX_CANDLES);
+
+      const raw = doc?.candles || doc?.data || [];
+      // normalize, dedupe-by-minute, sort asc, cap
+      const mapByMin = new Map();
+      for (const r of raw) {
+        const c = normalizeCandle({ ...r, timestamp: r.date ?? r.timestamp });
+        mapByMin.set(minuteKey(c.timestamp), c);
+      }
+      const arr = Array.from(mapByMin.values()).sort(
+        (a, b) => +a.timestamp - +b.timestamp
+      );
+      candleHistory[tokenStr] =
+        arr.length > HISTORY_CAP ? arr.slice(-HISTORY_CAP) : arr;
+
       delete loaders[tokenStr];
       return candleHistory[tokenStr];
     })();
@@ -35,24 +72,51 @@ export async function ensureCandleHistory(token) {
   return loaders[tokenStr];
 }
 
-export function pushCandle(token, candle, max = MAX_CANDLES) {
+// Upsert one candle (by minute), keep sorted, trim to cap
+export function pushCandle(token, candle, max = HISTORY_CAP) {
   const tokenStr = String(token);
-  if (!candleHistory[tokenStr]) candleHistory[tokenStr] = [];
-  candleHistory[tokenStr].push(candle);
-  if (candleHistory[tokenStr].length > max) {
-    candleHistory[tokenStr] = candleHistory[tokenStr].slice(-max);
+  const c = normalizeCandle(candle);
+  const key = minuteKey(c.timestamp);
+
+  const arr = candleHistory[tokenStr] || (candleHistory[tokenStr] = []);
+  const n = arr.length;
+
+  // Fast path: replace last if same minute
+  if (n && minuteKey(arr[n - 1].timestamp) === key) {
+    arr[n - 1] = c;
+  } else {
+    // Check if minute exists somewhere (late finalizer)
+    let idx = -1;
+    for (let i = n - 1; i >= 0; i--) {
+      if (minuteKey(arr[i].timestamp) === key) {
+        idx = i;
+        break;
+      }
+      if (+arr[i].timestamp < +c.timestamp) break; // small shortcut
+    }
+    if (idx >= 0) {
+      arr[idx] = c;
+    } else if (!n || +arr[n - 1].timestamp <= +c.timestamp) {
+      arr.push(c);
+    } else {
+      // Insert keeping ascending time order
+      let i = n - 1;
+      while (i >= 0 && +arr[i].timestamp > +c.timestamp) i--;
+      arr.splice(i + 1, 0, c);
+    }
+  }
+
+  if (arr.length > max) {
+    candleHistory[tokenStr] = arr.slice(-max);
   }
   return candleHistory[tokenStr];
 }
 
-export function pushCandles(token, candles, max = MAX_CANDLES) {
-  const tokenStr = String(token);
-  if (!candleHistory[tokenStr]) candleHistory[tokenStr] = [];
-  candleHistory[tokenStr].push(...candles);
-  if (candleHistory[tokenStr].length > max) {
-    candleHistory[tokenStr] = candleHistory[tokenStr].slice(-max);
+export function pushCandles(token, candles, max = HISTORY_CAP) {
+  for (const c of candles || []) {
+    pushCandle(token, c, max);
   }
-  return candleHistory[tokenStr];
+  return candleHistory[String(token)];
 }
 
 export function clearCandleHistory() {
@@ -60,11 +124,10 @@ export function clearCandleHistory() {
 }
 
 export async function preloadCandleHistory(tokens) {
-  const query = tokens && tokens.length ? { token: { $in: tokens.map(Number) } } : {};
-  const docs = await db
-    .collection("historical_session_data")
-    .find(query)
-    .toArray();
+  const query =
+    tokens && tokens.length ? { token: { $in: tokens.map(Number) } } : {};
+  const docs = await db.collection("historical_session_data").find(query).toArray();
+
   for (const doc of docs) {
     const tokenStr = String(doc.token);
     const data = doc.candles || doc.data || [];
@@ -76,9 +139,9 @@ export async function preloadCandleHistory(tokens) {
         low: c.low,
         close: c.close,
         volume: c.volume,
-        timestamp: new Date(c.date),
+        timestamp: c.date ?? c.timestamp,
       })),
-      MAX_CANDLES
+      HISTORY_CAP
     );
   }
 }


### PR DESCRIPTION
## Summary
- export a shared `HISTORY_CAP` constant and improve candle normalization helpers
- ensure candle history loading and in-memory updates dedupe by minute, keep sorted, and enforce the cap

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc7d555bb4832591cc0f26216969f6