### PR TITLE
Normalize stored candle dates and align cache limits

### DIFF
--- a/data/historicalStore.js
+++ b/data/historicalStore.js
@@ -3,7 +3,7 @@ import { logError } from '../logger.js';
 
 const defaults = {
   maxBarsDaily: 300,
-  maxBarsIntraday: 120,
+  maxBarsIntraday: 300,
   dailyStaleMs: 6 * 60 * 60 * 1000,
   intradayStaleMs: 5 * 60 * 1000,
   enableChangeStream: false,
@@ -59,11 +59,18 @@ function initHistoricalStore(options = {}) {
   function dedupeAndSort(arr) {
     const map = new Map();
     for (const c of arr || []) {
-      const t = +new Date(c.date || c.timestamp);
+      const t = +new Date(c.date ?? c.timestamp);
       if (!Number.isFinite(t)) continue;
-      if (!map.has(t)) map.set(t, { ...c, date: new Date(t).toISOString() });
+      if (!map.has(t)) {
+        const d = new Date(t);
+        map.set(t, {
+          ...c,
+          date: d,
+          timestamp: d,
+        });
+      }
     }
-    return [...map.values()].sort((a, b) => +new Date(a.date) - +new Date(b.date));
+    return [...map.values()].sort((a, b) => +a.date - +b.date);
   }
 
   async function detectDailyModel() {
@@ -86,11 +93,11 @@ function initHistoricalStore(options = {}) {
     let arr = candles || [];
     if (from) {
       const f = +new Date(from);
-      arr = arr.filter((c) => +new Date(c.date || c.timestamp) >= f);
+      arr = arr.filter((c) => +new Date(c.date ?? c.timestamp) >= f);
     }
     if (to) {
       const t = +new Date(to);
-      arr = arr.filter((c) => +new Date(c.date || c.timestamp) <= t);
+      arr = arr.filter((c) => +new Date(c.date ?? c.timestamp) <= t);
     }
     if (limit) arr = arr.slice(-limit);
     return arr;
@@ -148,7 +155,20 @@ function initHistoricalStore(options = {}) {
     const k = key(token);
     return withLock(dailyLocks, k, async () => {
       const entry = dailyCache.get(k) || { candles: [], lastLoadedAt: 0 };
-      const merged = dedupeAndSort([...entry.candles, ...candles]);
+      const normalized = candles
+        .map((c) => {
+          const raw = c.date ?? c.timestamp;
+          const date = c.date instanceof Date ? c.date : new Date(raw);
+          const timestamp =
+            c.timestamp instanceof Date ? c.timestamp : new Date(raw);
+          return {
+            ...c,
+            date,
+            timestamp,
+          };
+        })
+        .filter((c) => Number.isFinite(+c.date));
+      const merged = dedupeAndSort([...entry.candles, ...normalized]);
       const bounded = merged.slice(-cfg.maxBarsDaily);
       const start = Date.now();
       try {
@@ -157,13 +177,13 @@ function initHistoricalStore(options = {}) {
         if (model === 'single') {
           await col.updateOne(
             {},
-            { $push: { [k]: { $each: candles, $slice: -cfg.maxBarsDaily } } },
+            { $push: { [k]: { $each: normalized, $slice: -cfg.maxBarsDaily } } },
             { upsert: true }
           );
         } else {
           await col.updateOne(
             { token: Number(k) },
-            { $push: { candles: { $each: candles, $slice: -cfg.maxBarsDaily } } },
+            { $push: { candles: { $each: normalized, $slice: -cfg.maxBarsDaily } } },
             { upsert: true }
           );
         }
@@ -219,13 +239,26 @@ function initHistoricalStore(options = {}) {
     const k = key(token);
     return withLock(intradayLocks, k, async () => {
       const entry = intradayCache.get(k) || { candles: [], lastLoadedAt: 0 };
-      const merged = dedupeAndSort([...entry.candles, ...candles]);
+      const normalized = candles
+        .map((c) => {
+          const raw = c.date ?? c.timestamp;
+          const date = c.date instanceof Date ? c.date : new Date(raw);
+          const timestamp =
+            c.timestamp instanceof Date ? c.timestamp : new Date(raw);
+          return {
+            ...c,
+            date,
+            timestamp,
+          };
+        })
+        .filter((c) => Number.isFinite(+c.date));
+      const merged = dedupeAndSort([...entry.candles, ...normalized]);
       const bounded = merged.slice(-cfg.maxBarsIntraday);
       const start = Date.now();
       try {
         await db.collection('historical_session_data').updateOne(
           { token: Number(k) },
-          { $push: { candles: { $each: candles, $slice: -cfg.maxBarsIntraday } } },
+          { $push: { candles: { $each: normalized, $slice: -cfg.maxBarsIntraday } } },
           { upsert: true }
         );
         metric('onWriteMs', Date.now() - start, 'intraday');

--- a/kite.js
+++ b/kite.js
@@ -1298,16 +1298,18 @@ async function fetchHistoricalIntradayData(
         }
 
         // 3) Format and accumulate
-        const formatted = candles.map((c) => ({
-          date: new Date(c.date).toLocaleString("en-IN", {
-            timeZone: "Asia/Kolkata",
-          }),
-          open: c.open,
-          high: c.high,
-          low: c.low,
-          close: c.close,
-          volume: c.volume,
-        }));
+        const formatted = candles.map((c) => {
+          const d = new Date(c.date);
+          return {
+            date: d,
+            timestamp: d,
+            open: c.open,
+            high: c.high,
+            low: c.low,
+            close: c.close,
+            volume: c.volume,
+          };
+        });
 
         if (!historicalData[token]) {
           historicalData[token] = [];
@@ -1396,16 +1398,18 @@ async function fetchHistoricalData(symbols) {
         endDate
       );
       const tokenKey = String(token);
-      const formattedCandles = candles.map((c) => ({
-        date: new Date(c.date).toLocaleString("en-IN", {
-          timeZone: "Asia/Kolkata",
-        }),
-        open: c.open,
-        high: c.high,
-        low: c.low,
-        close: c.close,
-        volume: c.volume,
-      }));
+      const formattedCandles = candles.map((c) => {
+        const d = new Date(c.date);
+        return {
+          date: d,
+          timestamp: d,
+          open: c.open,
+          high: c.high,
+          low: c.low,
+          close: c.close,
+          volume: c.volume,
+        };
+      });
       await historicalCol.updateOne(
         {},
         { $set: { [tokenKey]: formattedCandles } },

--- a/tests/historicalStore.test.js
+++ b/tests/historicalStore.test.js
@@ -51,10 +51,14 @@ test('write-through append dedupe and bounds', async () => {
     { date:'2019-12-31', open:0, high:0, low:0, close:0, volume:0 }
   ]);
   assert.equal(res.length,2); // bounded to 2 most recent
-    assert.equal(res[0].date.startsWith('2020-01-01'), true);
+    assert.equal(res[0].date instanceof Date, true);
+    assert.equal(res[0].timestamp instanceof Date, true);
+    assert.equal(res[0].date.toISOString().startsWith('2020-01-01'), true);
     const doc = await db.collection('historical_data').findOne({});
     const arr = doc.candles || doc['3'];
     assert.equal(arr.length,2);
+    assert.equal(arr[0].date instanceof Date, true);
+    assert.equal(arr[0].timestamp instanceof Date, true);
 });
 
 test('concurrent reads load once', async () => {


### PR DESCRIPTION
## Summary
- normalize historical store deduplication to retain Date objects, align slicing with Date-aware comparisons, and increase intraday cache bounds
- coerce appended candles to Date-based shapes before caching or persisting and ensure Kite historical fetches emit Date objects
- adjust historical store test expectations to validate Date/timestamp handling

## Testing
- npm test -- tests/historicalStore.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dc82c047188325a4ef2f28e5c280ab