### PR TITLE
Expose configurable risk fallbacks

### DIFF
--- a/riskConfig.js
+++ b/riskConfig.js
@@ -1,12 +1,25 @@
-export const riskDefaults = {
+export const riskDefaults = Object.freeze({
   maxDailyLoss: Number(process.env.MAX_DAILY_LOSS) || 5000,
   maxDailyRisk: Number(process.env.MAX_DAILY_RISK) || 10000,
   maxTradesPerDay: Number(process.env.MAX_TRADES_PER_DAY) || 20,
   maxTradesPerInstrument: Number(process.env.MAX_TRADES_PER_INSTRUMENT) || 3,
   maxTradesPerSector: Number(process.env.MAX_TRADES_PER_SECTOR) || 10,
   maxLossStreak: Number(process.env.MAX_LOSS_STREAK) || 3,
-  maxSignalsPerDay: Number(process.env.MAX_SIGNALS_PER_DAY) || Infinity,
+  // Signals & throttles
+  maxSignalsPerDay: isFinite(Number(process.env.MAX_SIGNALS_PER_DAY))
+    ? Number(process.env.MAX_SIGNALS_PER_DAY)
+    : 300,
   signalFloodThreshold: Number(process.env.SIGNAL_FLOOD_THRESHOLD) || 0,
   volatilityThrottleMs: Number(process.env.VOLATILITY_THROTTLE_MS) || 0,
-};
+  maxSimultaneousSignals: Number(process.env.MAX_SIMULTANEOUS_SIGNALS) || 0,
+
+  // Optional drawdown controls (0 disables)
+  equityDrawdownLimitPct: Number(process.env.EQUITY_DRAWDOWN_LIMIT_PCT) || 0,
+  maxDailyLossPct: Number(process.env.MAX_DAILY_LOSS_PCT) || 0,
+  maxCumulativeLoss: Number(process.env.MAX_CUMULATIVE_LOSS) || 0,
+  maxWeeklyDrawdown: Number(process.env.MAX_WEEKLY_DRAWDOWN) || 0,
+  maxMonthlyDrawdown: Number(process.env.MAX_MONTHLY_DRAWDOWN) || 0,
+  maxLossPerTradePct: Number(process.env.MAX_LOSS_PER_TRADE_PCT) || 0,
+  maxOpenPositions: Number(process.env.MAX_OPEN_POSITIONS) || 0,
+});
 

--- a/scanner.js
+++ b/scanner.js
@@ -306,6 +306,11 @@ export async function analyzeCandles(
     });
 
     const riskCtx = {
+      // give RR validator real win-rate info
+      winrate:
+        (marketContext?.strategyWinrates?.[displayStrategy] ??
+          marketContext?.winrate ??
+          0),
       avgAtr: atrValue,
       indexTrend: isUptrend ? "up" : isDowntrend ? "down" : "sideways",
       indexVolatility: safeVix,


### PR DESCRIPTION
## Summary
- freeze the risk defaults and add environment-driven limits for signal throttles and drawdown controls
- use the shared risk configuration as a fallback for simultaneous signal, drawdown, and open position guards
- provide the risk engine with strategy win-rate data when building the scanner risk context

## Testing
- npm test *(terminated manually after tests appeared to hang despite individual cases passing)*

------
https://chatgpt.com/codex/tasks/task_e_68dc8d8d19c48325a0ca4c8f68423b4f