### PR TITLE
Fix strategy ATR usage and propagate risk metadata

### DIFF
--- a/scanner.js
+++ b/scanner.js
@@ -257,6 +257,10 @@ export async function analyzeCandles(
       atr: atrValue,
       spread,
       liquidity: effectiveLiquidity,
+      support,
+      resistance,
+      // let the risk validator use our category mapping
+      algoSignal: base.strategyCategory ? { strategy: base.strategyCategory } : undefined,
     };
 
     const momentumThresholds = {


### PR DESCRIPTION
## Summary
- update strategy engine sizing to rely on ATR, enforce consistent risk-reward ratios, and tag each signal with a strategy category
- guard against invalid risk calculations, compute ATR fallbacks for gap plays, and standardize target sizing across strategies
- provide scanner risk validation with support/resistance context and strategy category metadata

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68dd4116e9688325b9a23f95a533b06d