### PR TITLE
Enhance dynamic risk sizing with margin-aware caps

### DIFF
--- a/dynamicRiskModel.js
+++ b/dynamicRiskModel.js
@@ -1,6 +1,8 @@
 // dynamicRiskModel.js
 // Provides dynamic risk management utilities for trading strategies
 import { validateRR as baseValidateRR } from './riskValidator.js';
+import { DEFAULT_MARGIN_PERCENT } from './util.js';
+import { riskDefaults } from './riskConfig.js';
 
 /**
  * Calculate dynamic stop-loss based on ATR and setup confidence.
@@ -30,9 +32,19 @@ export function calculateDynamicStopLoss({
  * @param {number} [opts.riskAmount=0.01] - Risk per trade (percentage or absolute)
  * @param {number} opts.entry - Entry price
  * @param {number} opts.stopLoss - Stop loss price
- * @param {number} [opts.tickSize=1] - Minimum tick/lot size
- * @param {number} [opts.volatility] - Volatility metric to scale size
- * @param {number} [opts.capUtil=0.05] - Capital utilization cap per trade
+ * @param {number} [opts.qtyStep=1] - Minimum tradable quantity increment
+ * @param {number} [opts.tickSize] - Deprecated alias for qtyStep
+ * @param {number} [opts.volatility] - Volatility metric (e.g. ATR)
+ * @param {number} [opts.capUtil=0.05] - Legacy capital utilization cap per trade
+ * @param {number} [opts.price=entry] - Price used for margin estimation
+ * @param {number} [opts.leverage=0] - Available leverage multiplier
+ * @param {number} [opts.marginPercent] - Broker-provided margin percentage (alternative to leverage)
+ * @param {number} [opts.marginPerLot] - Explicit margin requirement per lot/step
+ * @param {number} [opts.marginBuffer=1] - Safety buffer applied to margin
+ * @param {number} [opts.exchangeMarginMultiplier=1] - Exchange-imposed multiplier
+ * @param {number} [opts.utilizationCap] - Override for capital utilization when margin provided
+ * @param {number} [opts.minQty] - Minimum allowable quantity
+ * @param {number} [opts.maxQty] - Maximum allowable quantity
  * @returns {number} quantity
  */
 export function calculateLotSize({
@@ -40,26 +52,98 @@ export function calculateLotSize({
   riskAmount = 0.01,
   entry,
   stopLoss,
-  tickSize = 1,
+  qtyStep = 1,
+  tickSize,
   volatility,
   capUtil = 0.05,
+  price = entry,
+  leverage = 0,
+  marginPercent,
+  marginPerLot,
+  marginBuffer = 1,
+  exchangeMarginMultiplier = 1,
+  utilizationCap,
+  minQty,
+  maxQty,
 }) {
   if (!capital || !entry || !stopLoss) return 0;
   const sl = Math.abs(entry - stopLoss);
   if (sl <= 0) return 0;
 
   const risk = riskAmount <= 1 ? capital * riskAmount : riskAmount;
-  let qty = risk / sl;
+  let qty = risk / Math.max(sl, 1e-6);
 
-  if (volatility && volatility > 2) {
-    const factor = Math.min(volatility / 2, 3);
-    qty /= factor;
+  const stepInput =
+    typeof tickSize === 'number' && !Number.isNaN(tickSize) ? tickSize : qtyStep;
+  const step = typeof stepInput === 'number' && stepInput > 0 ? stepInput : 1;
+  const roundDownToStep = (value) => {
+    if (!Number.isFinite(value) || value <= 0) return 0;
+    const scaled = value / step;
+    const floored = Math.floor(scaled + 1e-9);
+    return Number((floored * step).toFixed(8));
+  };
+  const roundUpToStep = (value) => {
+    if (!Number.isFinite(value)) return Number(step.toFixed(8));
+    if (value <= 0) return Number(step.toFixed(8));
+    const scaled = value / step;
+    const ceiled = Math.ceil(scaled - 1e-9);
+    return Number((ceiled * step).toFixed(8));
+  };
+
+  if (volatility && entry) {
+    const atrPct = (volatility / entry) * 100;
+    if (atrPct > 2) {
+      const factor = Math.min(atrPct / 2, 3);
+      qty /= factor;
+    }
   }
 
-  qty = Math.floor(qty / tickSize) * tickSize;
-  const maxQty = Math.floor((capital * capUtil) / entry);
-  if (maxQty > 0) qty = Math.min(qty, maxQty);
-  return qty;
+  qty = roundDownToStep(qty);
+
+  const marginPct =
+    typeof marginPercent === 'number'
+      ? marginPercent
+      : leverage > 0
+      ? 1 / leverage
+      : DEFAULT_MARGIN_PERCENT;
+  const effPrice = price || entry;
+  const marginMultiplier = (exchangeMarginMultiplier || 1) * (marginBuffer || 1);
+
+  let maxCapQty = Infinity;
+  const inferredMarginPerLot =
+    (marginPerLot || (effPrice ? effPrice * step * marginPct : 0)) * marginMultiplier;
+  if (inferredMarginPerLot > 0) {
+    const cap = typeof utilizationCap === 'number' ? utilizationCap : capUtil;
+    if (cap > 0) {
+      const maxLots = Math.floor((capital * cap) / inferredMarginPerLot);
+      const capQty = Number((maxLots * step).toFixed(8));
+      maxCapQty = capQty;
+      if (capQty <= 0) return 0;
+      qty = Math.min(qty, capQty);
+    }
+  } else if (effPrice > 0) {
+    const legacyMaxUnits = Math.floor((capital * capUtil) / effPrice);
+    const capQty = roundDownToStep(legacyMaxUnits);
+    maxCapQty = capQty;
+    if (capQty <= 0) return 0;
+    qty = Math.min(qty, capQty);
+  }
+
+  let minRounded;
+  if (typeof minQty === 'number' && minQty > 0) {
+    minRounded = roundUpToStep(minQty);
+    if (maxCapQty < minRounded) return 0;
+    if (qty < minRounded) qty = minRounded;
+  }
+
+  if (typeof maxQty === 'number' && maxQty > 0) {
+    const maxRounded = roundDownToStep(maxQty);
+    if (maxRounded <= 0) return 0;
+    if (typeof minRounded === 'number' && minRounded > maxRounded) return 0;
+    qty = Math.min(qty, maxRounded);
+  }
+
+  return qty > 0 ? qty : 0;
 }
 
 export function validateRR(args) {
@@ -69,7 +153,7 @@ export function validateRR(args) {
 /**
  * Check exposure caps before placing a new trade.
  * @param {Object} opts
- * @param {Object} opts.positions - Current open positions map { sym: { value, sector } }
+ * @param {Object|Map} opts.positions - Current open positions map { sym: { value, sector } }
  * @param {string} opts.instrument - Instrument symbol
  * @param {string} opts.sector - Instrument sector
  * @param {number} opts.tradeValue - Value of the potential trade
@@ -89,11 +173,15 @@ export function checkExposureCap({
   const secCaps = { default: 0.25, ...(caps.sector || {}) };
   const secCap = (secCaps[sector] ?? secCaps.default) * totalCapital;
 
-  const currentInst = positions[instrument]?.value || 0;
+  const getAll = () =>
+    positions instanceof Map ? Array.from(positions.values()) : Object.values(positions || {});
+  const getFor = (sym) => (positions instanceof Map ? positions.get(sym) : positions?.[sym]);
+
+  const currentInst = getFor(instrument)?.value || 0;
   if (currentInst + tradeValue > instCap) return false;
 
   let currentSector = 0;
-  for (const pos of Object.values(positions)) {
+  for (const pos of getAll()) {
     if (pos.sector === sector) currentSector += pos.value;
   }
   if (currentSector + tradeValue > secCap) return false;
@@ -108,8 +196,13 @@ export function checkExposureCap({
  * @returns {number} adjusted lot size
  */
 export function adjustRiskBasedOnDrawdown({ drawdown, lotSize }) {
-  if (drawdown > 0.1) return 0;
-  if (drawdown > 0.05) return Math.floor(lotSize * 0.5);
+  if (typeof drawdown !== 'number') return lotSize;
+  const halt = riskDefaults.drawdownHaltPct ?? 0.15;
+  const cut50 = riskDefaults.drawdownReduce50Pct ?? 0.1;
+  const cut25 = riskDefaults.drawdownReduce25Pct ?? 0.05;
+  if (drawdown >= halt) return 0;
+  if (drawdown >= cut50) return Math.floor(lotSize * 0.5);
+  if (drawdown >= cut25) return Math.floor(lotSize * 0.75);
   return lotSize;
 }
 
@@ -121,8 +214,9 @@ export function adjustRiskBasedOnDrawdown({ drawdown, lotSize }) {
  * @returns {number} adjusted lot size
  */
 export function adjustRiskAfterLossStreak({ lossStreak = 0, lotSize }) {
-  if (lossStreak >= 3) return Math.floor(lotSize * 0.5);
-  if (lossStreak === 2) return Math.floor(lotSize * 0.75);
+  const maxLs = riskDefaults.maxLossStreak ?? 3;
+  if (lossStreak >= maxLs) return Math.floor(lotSize * 0.5);
+  if (lossStreak === Math.max(1, maxLs - 1)) return Math.floor(lotSize * 0.75);
   return lotSize;
 }
 
@@ -133,8 +227,15 @@ export function adjustRiskAfterLossStreak({ lossStreak = 0, lotSize }) {
  * @param {number} opts.entry - Entry price
  * @param {string} opts.direction - Trade direction
  * @param {number} opts.capital - Account balance
- * @param {number} opts.risk - Risk per trade
+ * @param {number} opts.risk - Risk per trade (percent or absolute)
  * @param {number} [opts.volatility] - Volatility metric
+ * @param {number} [opts.qtyStep] - Quantity increment size
+ * @param {number} [opts.leverage] - Broker leverage multiplier
+ * @param {number} [opts.marginPercent] - Margin percentage
+ * @param {number} [opts.marginPerLot] - Explicit margin per lot
+ * @param {number} [opts.marginBuffer=1] - Margin safety buffer
+ * @param {number} [opts.exchangeMarginMultiplier=1] - Exchange margin multiplier
+ * @param {number} [opts.utilizationCap] - Capital utilization cap
  * @returns {Object} { stopLoss, qty }
  */
 export function realTimeRiskController({
@@ -144,6 +245,13 @@ export function realTimeRiskController({
   capital,
   risk,
   volatility,
+  qtyStep,
+  leverage = 0,
+  marginPercent,
+  marginPerLot,
+  marginBuffer = 1,
+  exchangeMarginMultiplier = 1,
+  utilizationCap,
 }) {
   const stopLoss = calculateDynamicStopLoss({ atr, entry, direction });
   const qty = calculateLotSize({
@@ -152,6 +260,13 @@ export function realTimeRiskController({
     entry,
     stopLoss,
     volatility,
+    qtyStep,
+    leverage,
+    marginPercent,
+    marginPerLot,
+    marginBuffer,
+    exchangeMarginMultiplier,
+    utilizationCap,
   });
   return { stopLoss, qty };
 }

--- a/riskConfig.js
+++ b/riskConfig.js
@@ -14,6 +14,9 @@ export const riskDefaults = Object.freeze({
   maxSimultaneousSignals: Number(process.env.MAX_SIMULTANEOUS_SIGNALS) || 0,
 
   // Optional drawdown controls (0 disables)
+  drawdownReduce25Pct: Number(process.env.DD_REDUCE_25_PCT) || 0.05,
+  drawdownReduce50Pct: Number(process.env.DD_REDUCE_50_PCT) || 0.1,
+  drawdownHaltPct: Number(process.env.DD_HALT_PCT) || 0.15,
   equityDrawdownLimitPct: Number(process.env.EQUITY_DRAWDOWN_LIMIT_PCT) || 0,
   maxDailyLossPct: Number(process.env.MAX_DAILY_LOSS_PCT) || 0,
   maxCumulativeLoss: Number(process.env.MAX_CUMULATIVE_LOSS) || 0,


### PR DESCRIPTION
## Summary
- normalize lot size calculation with ATR% scaling, margin-aware caps, qty step aliasing, and optional quantity clamps
- make drawdown and loss-streak risk reductions configurable and support Map-based exposure caps
- extend real-time risk controller wiring and expose new drawdown defaults in the risk configuration

## Testing
- npm test *(fails: analyzeCandles returns a signal for valid data)*

------
https://chatgpt.com/codex/tasks/task_e_68dd5ab24a34832582d79f7238263e06