### PR TITLE
Normalize sides and harden signal risk handling

### DIFF
--- a/kite.js
+++ b/kite.js
@@ -7,7 +7,6 @@ import fs from "fs";
 import path from "path";
 import dotenv from "dotenv";
 import { fileURLToPath } from "url";
-import { ObjectId } from "mongodb";
 import { fetchAIData } from "./openAI.js";
 import { logSignalCreated, logSignalRejected } from "./auditLogger.js";
 import { logError, logWarnOncePerToken } from "./logger.js";
@@ -250,7 +249,9 @@ async function removeStockSymbol(symbol) {
       .collection("historical_data")
       .updateOne({}, { $unset: { [tokenStr]: "" } });
     // await db.collection('session_data').updateOne({}, { $unset: { [tokenStr]: '' } });
-    await db.collection("session_data").deleteOne({ token: Number(tokenStr) });
+    await db
+      .collection("session_data")
+      .deleteMany({ token: Number(tokenStr) });
     await db
       .collection("historical_session_data")
       .deleteMany({ token: Number(tokenStr) });
@@ -1201,7 +1202,7 @@ async function emitUnifiedSignal(signal, source, io = globalIO) {
   const exposureAllowed = checkExposureLimits(exposureOptions);
   const conflictAllowed = resolveSignalConflicts({
     symbol,
-    side: signal.direction === "Long" ? "long" : "short",
+    side: signal.direction === "Long" ? "buy" : "sell",
     strategy: signal.pattern,
   });
 

--- a/scanner.js
+++ b/scanner.js
@@ -367,21 +367,26 @@ export async function analyzeCandles(
     const riskOk =
       typeof riskVerdict === "object" ? !!riskVerdict.ok : !!riskVerdict;
     if (!riskOk) {
-      const debugTrace = Array.isArray(riskCtx.debugTrace)
-        ? riskCtx.debugTrace
-        : Array.isArray(riskVerdict?.trace)
-        ? riskVerdict.trace
-        : [];
-      const reasonSummary =
-        (typeof riskVerdict === "object" && riskVerdict.reason) ||
-        debugTrace.map((d) => d.code).join(", ") ||
-        "riskValidationFail";
-      console.log(`[RISK] ${symbol} blocked: ${reasonSummary}`);
+      const reason =
+        typeof riskVerdict === "object" ? riskVerdict.reason : "riskValidationFail";
+      const debugTrace =
+        (typeof riskVerdict === "object" &&
+          Array.isArray(riskVerdict.trace) &&
+          riskVerdict.trace) ||
+        (Array.isArray(riskCtx.debugTrace) && riskCtx.debugTrace) ||
+        null;
+      if (debugTrace?.length) {
+        const reasonSummary = debugTrace.map((entry) => entry.code).join(", ");
+        console.log(`[RISK] ${symbol} blocked: ${reasonSummary}`);
+      }
       try {
+        const rejectionCtx = debugTrace?.length
+          ? { ...riskCtx, debugTrace: [...debugTrace] }
+          : riskCtx;
         await logSignalRejected(
           `${symbol}-${Date.now()}`,
-          reasonSummary,
-          { ...riskCtx, debugTrace },
+          reason,
+          rejectionCtx,
           preliminary
         );
       } catch (e) {


### PR DESCRIPTION
## Summary
- normalize order sides to the canonical buy/sell form across the Kite signal emission and portfolio tracking utilities
- refresh portfolio position bookkeeping to normalize broker data, persist entry fills, and reuse storage writes
- resolve the scanner risk gate merge artifact and improve rejection logging to preserve debug traces

## Testing
- `npm test` *(fails: account module import mocks require applyRealizedPnL export during experimental module mocking)*

------
https://chatgpt.com/codex/tasks/task_e_68dd661dd36c8325a42a1249462f92ed