### PR TITLE
Harden risk engine defaults and telemetry

### DIFF
--- a/scanner.js
+++ b/scanner.js
@@ -370,11 +370,11 @@ export async function analyzeCandles(
       const reason =
         typeof riskVerdict === "object" ? riskVerdict.reason : "riskValidationFail";
       const debugTrace =
-        (typeof riskVerdict === "object" &&
-          Array.isArray(riskVerdict.trace) &&
-          riskVerdict.trace) ||
-        (Array.isArray(riskCtx.debugTrace) && riskCtx.debugTrace) ||
-        null;
+        typeof riskVerdict === "object" && Array.isArray(riskVerdict.trace)
+          ? riskVerdict.trace
+          : Array.isArray(riskCtx.debugTrace)
+          ? riskCtx.debugTrace
+          : null;
       if (debugTrace?.length) {
         const reasonSummary = debugTrace.map((entry) => entry.code).join(", ");
         console.log(`[RISK] ${symbol} blocked: ${reasonSummary}`);


### PR DESCRIPTION
## Summary
- merge risk configuration over safe defaults to avoid NaNs and add snapshot helper for telemetry
- tighten runtime guards in the risk engine for ATR, RSI, spread and volume checks while preserving detailed rejection context
- clean up scanner risk rejection logging to prefer risk verdict traces when present

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddd5b001fc832588c707f321f68c18