### PR TITLE
Harden candle sanitization and ATR-scaled pattern detection

### DIFF
--- a/scanner.js
+++ b/scanner.js
@@ -10,6 +10,7 @@ import {
   getWickNoise,
   isAtrStable,
   isAwayFromConsolidation,
+  sanitizeCandles,
 } from "./util.js";
 
 import {
@@ -104,28 +105,16 @@ export async function analyzeCandles(
       return null;
     }
 
-    // Filter out malformed candle objects
-    const validCandles = candles.filter(
-      (c) =>
-        c &&
-        typeof c.open === "number" &&
-        !isNaN(c.open) &&
-        typeof c.high === "number" &&
-        !isNaN(c.high) &&
-        typeof c.low === "number" &&
-        !isNaN(c.low) &&
-        typeof c.close === "number" &&
-        !isNaN(c.close)
-    );
-    if (validCandles.length < 5) return null;
-    const features = computeFeatures(validCandles);
+    const cleanCandles = sanitizeCandles(candles);
+    if (cleanCandles.length < 5) return null;
+    const features = computeFeatures(cleanCandles);
     if (!features) return null;
 
     const tokenNum = await getTokenForSymbol(symbol);
     const tokenStr =
       tokenNum !== undefined && tokenNum !== null ? String(tokenNum) : null;
     const dailyHistory = tokenStr ? await getHistoricalData(tokenStr) : [];
-    const sessionData = candles;
+    const sessionData = cleanCandles;
 
     const {
       ema9,
@@ -143,12 +132,12 @@ export async function analyzeCandles(
       trendStrength,
       volatilityClass,
     } = features;
-    const last = validCandles.at(-1);
+    const last = cleanCandles.at(-1);
     const lastVol = (last && (last.volume ?? last.v ?? last.qty)) ?? 0;
     const effectiveLiquidity = liquidity || avgVolume || lastVol || 0;
     const context = {
       symbol,
-      candles: validCandles,
+      candles: cleanCandles,
       features,
       depth,
       tick: liveTick,
@@ -171,8 +160,8 @@ export async function analyzeCandles(
     }
 
     const wickPct = last ? getWickNoise(last) : 0;
-    const strongPriceAction = isStrongPriceAction(validCandles);
-    const atrStable = isAtrStable(validCandles);
+    const strongPriceAction = isStrongPriceAction(cleanCandles);
+    const atrStable = isAtrStable(cleanCandles);
     const expiryMinutesRaw = calculateExpiryMinutes({ atr: atrValue, rvol });
     const expiryMinutes =
       Number.isFinite(expiryMinutesRaw) && expiryMinutesRaw > 0
@@ -217,7 +206,7 @@ export async function analyzeCandles(
       accountBalance,
       riskPerTradePercentage,
     });
-    const altStrategies = evaluateStrategies(validCandles, {
+    const altStrategies = evaluateStrategies(cleanCandles, {
       topN: 1,
     });
     const filtered = filterStrategiesByRegime(stratResults, marketContext);
@@ -408,7 +397,7 @@ export async function analyzeCandles(
       ? Math.abs((base.target2 ?? base.target1) - base.entry)
       : 0;
     const riskReward = baseRisk > 0 ? rrNumerator / baseRisk : 0;
-    const consolidationOk = isAwayFromConsolidation(validCandles, base.entry);
+    const consolidationOk = isAwayFromConsolidation(cleanCandles, base.entry);
     const { getDrawdown } = await import("./account.js");
     const dd = typeof getDrawdown === "function" ? getDrawdown() : 0;
     let qty = calculatePositionSize({

--- a/tests/analyzeCandles.test.js
+++ b/tests/analyzeCandles.test.js
@@ -83,8 +83,21 @@ const utilMock = test.mock.module('../util.js', {
     calculateZScore: () => 0,
     patternConfluenceAcrossTimeframes: () => true,
     DEFAULT_MARGIN_PERCENT: 0.2,
-    calculateRequiredMargin: () => 100
+    calculateRequiredMargin: () => 100,
+    sanitizeCandles: (candles) => candles
   }
+});
+
+const riskMock = test.mock.module('../riskEngine.js', {
+  namedExports: {
+    isSignalValid: () => true,
+    riskState: {
+      dailyLoss: 0,
+      consecutiveLosses: 0,
+      lastResetDay: new Date().getDate(),
+      signalCount: 0,
+    },
+  },
 });
 
 const dbMock = test.mock.module('../db.js', {
@@ -122,6 +135,7 @@ test('analyzeCandles returns a signal for valid data', async () => {
   kiteMock.restore();
   featureMock.restore();
   utilMock.restore();
+  riskMock.restore();
   auditMock.restore();
   dbMock.restore();
 });

--- a/tests/newPatterns.test.js
+++ b/tests/newPatterns.test.js
@@ -32,6 +32,7 @@ const utilMock = test.mock.module('../util.js', {
     patternConfluenceAcrossTimeframes: () => true,
     DEFAULT_MARGIN_PERCENT: 0.2,
     calculateRequiredMargin: () => 100,
+    sanitizeCandles: (candles) => candles,
   }
 });
 const dbMock = test.mock.module('../db.js', { defaultExport: {}, namedExports: { connectDB: async () => ({}) } });


### PR DESCRIPTION
## Summary
- add a reusable candle sanitizer and feed it through pattern detection, aggregation, and pattern confluence logic so NaNs and bad ranges are filtered out
- scale candlestick pattern thresholds by price/ATR, expose ATR-aware confirmRetest tolerances, and compute real ATR before multi-timeframe checks
- sanitize scanner/strategy inputs, compute ATR before detectAllPatterns usage, and update tests/mocks for the new helpers

## Testing
- npm test --silent *(fails: portfolioContext.js imports applyRealizedPnL and remote data requirements in confidence suite)*

------
https://chatgpt.com/codex/tasks/task_e_68dddcb03da08325b2cd47bee72f6ff4