### PR TITLE
Fix tweezer pattern detection reference

### DIFF
--- a/util.js
+++ b/util.js
@@ -474,9 +474,9 @@ export function detectAllPatterns(candles, atrValue, lookback = 5) {
       confidence: "Medium",
     });
   const tweezerBottom =
-    prev.close < prev.open &&
+    prevCandle.close < prevCandle.open &&
     last.close > last.open &&
-    Math.abs(prev.low - last.low) < epsilon;
+    Math.abs(prevCandle.low - last.low) < epsilon;
   if (tweezerBottom)
     patterns.push({
       type: "Tweezer Bottom",
@@ -485,9 +485,9 @@ export function detectAllPatterns(candles, atrValue, lookback = 5) {
       confidence: "Medium",
     });
   const tweezerTop =
-    prev.close > prev.open &&
+    prevCandle.close > prevCandle.open &&
     last.close < last.open &&
-    Math.abs(prev.high - last.high) < epsilon;
+    Math.abs(prevCandle.high - last.high) < epsilon;
   if (tweezerTop)
     patterns.push({
       type: "Tweezer Top",


### PR DESCRIPTION
## Summary
- correct tweezer candlestick detection to reference the previous candle when evaluating bottom/top setups

## Testing
- npm test *(fails: SyntaxError: The requested module './account.js' does not provide an export named 'applyRealizedPnL')*


------
https://chatgpt.com/codex/tasks/task_e_68df803c12c883259c873524d4d2b55b