### PR TITLE
Implement ATR-based supertrend and feature caching options

### DIFF
--- a/kite.js
+++ b/kite.js
@@ -1777,7 +1777,7 @@ export async function getHigherTimeframeData(symbol, timeframe = "15minute") {
 
     const closes = candles.map((c) => c.close);
     const ema50 = calculateEMA(closes, 50);
-    const supertrend = calculateSupertrend(candles, 50);
+    const supertrend = calculateSupertrend(candles, 50, 3);
 
     return { ema50, supertrend };
   } catch (err) {

--- a/scanner.js
+++ b/scanner.js
@@ -119,7 +119,10 @@ export async function analyzeCandles(
 
     const cleanCandles = sanitizeCandles(candles);
     if (cleanCandles.length < 5) return null;
-    const features = computeFeatures(cleanCandles);
+    const features = computeFeatures(cleanCandles, {
+      seriesKey: symbol ? `${symbol}:primary` : null,
+      supertrendSettings: { atrLength: 10, multiplier: 3 },
+    });
     if (!features) return null;
 
     const tokenNum = await getTokenForSymbol(symbol);

--- a/util.js
+++ b/util.js
@@ -204,7 +204,7 @@ export function analyzeHigherTimeframe(
   if (!candles || candles.length < emaLength) return null;
   const closes = candles.map((c) => c.close);
   const ema = calculateEMA(closes, emaLength);
-  const supertrend = calculateSupertrend(candles, atrLength);
+  const supertrend = calculateSupertrend(candles, atrLength, 3);
   return { ema, supertrend };
 }
 


### PR DESCRIPTION
## Summary
- replace the stubbed Supertrend with an ATR-based implementation and add Wilder-smoothed RSI/ATR plus safer VWAP/Williams %R calculations
- extend computeFeatures with optional series caching and Supertrend settings and wire the new options through the scanner, strategies, and strategy engine
- update higher-timeframe helpers to use the new Supertrend defaults

## Testing
- `npm test --silent` *(fails: portfolioContext.js imports applyRealizedPnL which is not exported by account.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e007f7563483258a9205692919a8ac