### PR TITLE
Adjust position sizing to account for costs and margin limits

### DIFF
--- a/scanner.js
+++ b/scanner.js
@@ -353,13 +353,46 @@ export async function analyzeCandles(
     const consolidationOk = isAwayFromConsolidation(cleanCandles, base.entry);
     const { getDrawdown } = await import("./account.js");
     const dd = typeof getDrawdown === "function" ? getDrawdown() : 0;
+    const sizingOverrides = {};
+    const setIfDefined = (key, value) => {
+      if (value !== undefined) sizingOverrides[key] = value;
+    };
+    setIfDefined('lotSize', base.lotSize ?? riskDefaults.lotSize);
+    setIfDefined('minLotSize', base.minLotSize ?? riskDefaults.minLotSize);
+    setIfDefined('minQty', base.minQty ?? riskDefaults.minQty);
+    setIfDefined('maxQty', base.maxQty ?? riskDefaults.maxQty);
+    setIfDefined(
+      'leverage',
+      base.leverage ?? riskDefaults.leverage ?? marketContext?.leverage
+    );
+    setIfDefined(
+      'marginPercent',
+      base.marginPercent ?? riskDefaults.marginPercent ?? marketContext?.marginPercent
+    );
+    setIfDefined('marginPerLot', base.marginPerLot ?? riskDefaults.marginPerLot);
+    setIfDefined(
+      'utilizationCap',
+      base.utilizationCap ?? riskDefaults.utilizationCap ?? marketContext?.utilizationCap
+    );
+    setIfDefined('marginBuffer', base.marginBuffer ?? riskDefaults.marginBuffer);
+    setIfDefined(
+      'exchangeMarginMultiplier',
+      base.exchangeMarginMultiplier ?? riskDefaults.exchangeMarginMultiplier
+    );
+    setIfDefined(
+      'costBuffer',
+      base.costBuffer ?? riskDefaults.costBuffer ?? marketContext?.costBuffer
+    );
+    setIfDefined('drawdown', dd);
+    setIfDefined('lossStreak', riskState?.consecutiveLosses ?? base.lossStreak);
+
     let qty = calculatePositionSize({
       capital: accountBalance,
       risk: accountBalance * riskPerTradePercentage,
       slPoints: baseRisk,
       price: base.entry,
       volatility: atrValue,
-      drawdown: dd,
+      ...sizingOverrides,
     });
     if (riskReward > 2) qty = Math.floor(qty * 1.1);
     else if (riskReward < 1.2) qty = Math.floor(qty * 0.9);

--- a/strategyEngine.js
+++ b/strategyEngine.js
@@ -7,6 +7,39 @@ const DEFAULT_SUPERTREND_SETTINGS = { atrLength: 10, multiplier: 3 };
 const MAX_SPREAD_PCT = 0.5; // reject signals when quoted spread > 0.5% of price
 const MIN_LIQUIDITY = 0;    // keep 0 if you don’t have a liquidity scale yet
 
+function extractSizingParams(context = {}) {
+  const {
+    lotSize,
+    minLotSize,
+    minQty,
+    leverage,
+    marginPercent,
+    marginPerLot,
+    utilizationCap,
+    marginBuffer,
+    exchangeMarginMultiplier,
+    costBuffer,
+    drawdown,
+    lossStreak,
+    maxQty,
+  } = context || {};
+  return {
+    lotSize,
+    minLotSize,
+    minQty,
+    leverage,
+    marginPercent,
+    marginPerLot,
+    utilizationCap,
+    marginBuffer,
+    exchangeMarginMultiplier,
+    costBuffer,
+    drawdown,
+    lossStreak,
+    maxQty,
+  };
+}
+
 function buildSeriesKey(ctx = {}, fallback = 'strategy') {
   if (!ctx || typeof ctx !== 'object') return null;
   const symbol = ctx.symbol ?? null;
@@ -66,6 +99,7 @@ export function strategySupertrend(context = {}) {
       slPoints: risk,
       price: entry,
       volatility: atr,
+      ...extractSizingParams(context),
     });
     qty = Math.max(1, Math.floor(qty || 0));
     return {
@@ -104,6 +138,7 @@ export function strategySupertrend(context = {}) {
       slPoints: risk,
       price: entry,
       volatility: atr,
+      ...extractSizingParams(context),
     });
     qty = Math.max(1, Math.floor(qty || 0));
     return {
@@ -176,6 +211,7 @@ export function strategyEMAReversal(context = {}) {
       slPoints: risk,
       price: entry,
       volatility: atr,
+      ...extractSizingParams(context),
     });
     qty = Math.max(1, Math.floor(qty || 0));
     return {
@@ -210,6 +246,7 @@ export function strategyEMAReversal(context = {}) {
       slPoints: risk,
       price: entry,
       volatility: atr,
+      ...extractSizingParams(context),
     });
     qty = Math.max(1, Math.floor(qty || 0));
     return {
@@ -282,6 +319,7 @@ export function strategyTripleTop(context = {}) {
     slPoints: risk,
     price: entry,
     volatility: atr,
+    ...extractSizingParams(context),
   });
   qty = Math.max(1, Math.floor(qty || 0));
   return {
@@ -350,6 +388,7 @@ export function strategyVWAPReversal(context = {}) {
     slPoints: risk,
     price: entry,
     volatility: atr,
+    ...extractSizingParams(context),
   });
   qty = Math.max(1, Math.floor(qty || 0));
 
@@ -436,6 +475,7 @@ export function patternBasedStrategy(context = {}) {
     slPoints: risk,
     price: entry,
     volatility: atr,
+    ...extractSizingParams(context),
   });
   qty = Math.max(1, Math.floor(qty || 0));
   const dir = direction === 'Long' ? 1 : -1;
@@ -507,6 +547,7 @@ export function strategyGapUpDown(context = {}) {
     slPoints: risk,
     price: entry,
     volatility: atr,
+    ...extractSizingParams(context),
   });
   qty = Math.max(1, Math.floor(qty || 0));
   const target1 =

--- a/tests/positionSizing.test.js
+++ b/tests/positionSizing.test.js
@@ -18,6 +18,7 @@ const {
   calculatePositionSize,
   kellyCriterionSize,
   equalCapitalAllocation,
+  estimateRequiredMarginPerLot,
 } = await import('../positionSizing.js');
 const { atrStopLossDistance, calculateRequiredMargin } = await import('../util.js');
 
@@ -82,7 +83,7 @@ test('marginBuffer reduces allowed quantity', () => {
   assert.equal(qty, 83);
 });
 
-test('costBuffer scales risk amount', () => {
+test('costBuffer inflates stop distance before sizing', () => {
   const qty = calculatePositionSize({
     capital: 10000,
     risk: 1000,
@@ -90,6 +91,17 @@ test('costBuffer scales risk amount', () => {
     costBuffer: 1.1,
   });
   assert.equal(qty, 90);
+});
+
+test('estimateRequiredMarginPerLot applies buffers consistently', () => {
+  const margin = estimateRequiredMarginPerLot({
+    price: 100,
+    lotSize: 10,
+    marginPercent: 0.2,
+    exchangeMarginMultiplier: 1.5,
+    marginBuffer: 1.1,
+  });
+  assert.equal(margin, 100 * 10 * 0.2 * 1.5 * 1.1);
 });
 
 test('kellyCriterionSize computes fraction', () => {

--- a/tradeLifecycle.js
+++ b/tradeLifecycle.js
@@ -71,8 +71,19 @@ export async function executeSignal(signal, opts = {}) {
       risk: opts.risk || 0.01,
       slPoints: Math.abs(signal.entry - signal.stopLoss),
       price: signal.entry,
+      lotSize: opts.lotSize,
+      minLotSize: opts.minLotSize,
       minQty: opts.minQty,
       maxQty: opts.maxQty,
+      leverage: opts.leverage,
+      marginPercent: opts.marginPercent,
+      marginPerLot: opts.marginPerLot,
+      utilizationCap: opts.utilizationCap,
+      marginBuffer: opts.marginBuffer,
+      exchangeMarginMultiplier: opts.exchangeMarginMultiplier,
+      costBuffer: opts.costBuffer,
+      drawdown: opts.drawdown,
+      lossStreak: opts.lossStreak,
     });
   if (qty <= 0) return null;
   const tradeValue = signal.entry * qty;


### PR DESCRIPTION
## Summary
- apply the cost buffer to the stop distance, add a reusable margin estimator, and tighten rounding and margin guards in position sizing
- remove duplicate drawdown throttling in trade parameter calculation and thread sizing controls through the strategy engine, scanner, and trade execution
- expand unit tests to cover the new margin helper and updated cost buffer behaviour

## Testing
- `npm test` *(fails: existing test suite expects applyRealizedPnL export in account.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e27ec65fd88325bc35c95a702e8521