### PR TITLE
Propagate cost-aware sizing inputs and diagnostics

### DIFF
--- a/auditLogger.js
+++ b/auditLogger.js
@@ -48,6 +48,16 @@ export async function logSignalCreated(signalData, marketCtx = {}) {
     targetPrice: signalData.target2 || signalData.target,
     confidence: signalData.confidence || signalData.confidenceScore,
     timeframe: signalData.timeframe || '1m',
+    rawStopDistance: signalData.rawStopDistance ?? signalData.sizing?.rawDistance ?? null,
+    effectiveStopDistance:
+      signalData.effectiveStopDistance ?? signalData.sizing?.effectiveDistance ?? null,
+    requestedQty: signalData.sizing?.requestedQty ?? null,
+    finalQty: signalData.qty ?? null,
+    marginCapQty: signalData.sizing?.marginCap?.capQty ?? null,
+    marginCapped: signalData.sizing?.marginCapped ?? null,
+    costBuffer: signalData.costBuffer ?? null,
+    slippage: signalData.slippage ?? null,
+    spread: signalData.spread ?? null,
     market: {
       vix: marketCtx.vix,
       atr: signalData.atr,

--- a/kite.js
+++ b/kite.js
@@ -1226,6 +1226,17 @@ async function emitUnifiedSignal(signal, source, io = globalIO) {
     );
     return;
   }
+  const sizingInfo = signal.sizing || {};
+  const sizingLog = {
+    rawSL: signal.rawStopDistance ?? sizingInfo.rawDistance ?? null,
+    effectiveSL: signal.effectiveStopDistance ?? sizingInfo.effectiveDistance ?? null,
+    requestedQty: sizingInfo.requestedQty ?? sizingInfo.roundedQty ?? null,
+    finalQty: signal.qty,
+    marginCapQty: sizingInfo.marginCap?.capQty ?? null,
+    marginCapLots: sizingInfo.marginCap?.maxLots ?? null,
+    marginCapped: Boolean(sizingInfo.marginCapped),
+  };
+  console.log(`[SIZING] ${symbol}`, sizingLog);
   console.log(`🚀 Emitting ${source} Signal:`, signal);
   // Guard against missing socket instance which previously threw and prevented
   // signal propagation

--- a/strategyEngine.js
+++ b/strategyEngine.js
@@ -22,6 +22,9 @@ function extractSizingParams(context = {}) {
     drawdown,
     lossStreak,
     maxQty,
+    slippage: ctxSlippage,
+    inferredSlippage,
+    spread: ctxSpread,
   } = context || {};
   return {
     lotSize,
@@ -37,6 +40,13 @@ function extractSizingParams(context = {}) {
     drawdown,
     lossStreak,
     maxQty,
+    slippage:
+      typeof ctxSlippage === 'number'
+        ? ctxSlippage
+        : typeof inferredSlippage === 'number'
+        ? inferredSlippage
+        : undefined,
+    spread: ctxSpread,
   };
 }
 

--- a/tests/positionSizing.test.js
+++ b/tests/positionSizing.test.js
@@ -93,6 +93,17 @@ test('costBuffer inflates stop distance before sizing', () => {
   assert.equal(qty, 90);
 });
 
+test('slippage and spread reduce position size', () => {
+  const qty = calculatePositionSize({
+    capital: 10000,
+    risk: 1000,
+    slPoints: 10,
+    slippage: 1,
+    spread: 1,
+  });
+  assert.equal(qty, 83);
+});
+
 test('estimateRequiredMarginPerLot applies buffers consistently', () => {
   const margin = estimateRequiredMarginPerLot({
     price: 100,

--- a/tradeLifecycle.js
+++ b/tradeLifecycle.js
@@ -82,6 +82,8 @@ export async function executeSignal(signal, opts = {}) {
       marginBuffer: opts.marginBuffer,
       exchangeMarginMultiplier: opts.exchangeMarginMultiplier,
       costBuffer: opts.costBuffer,
+      slippage: opts.slippage,
+      spread: opts.spread,
       drawdown: opts.drawdown,
       lossStreak: opts.lossStreak,
     });


### PR DESCRIPTION
## Summary
- incorporate slippage, spread, and cost buffer handling into core position sizing along with diagnostics hooks
- feed the enhanced sizing inputs and metadata through scanners, signals, and trade execution while logging sizing decisions
- adjust the risk model backtest and audit logging to work with effective stop distances and optional lot sizing

## Testing
- node --test tests/positionSizing.test.js *(fails: TypeError: test.mock.module is not a function under Node.js v20.19.4)*

------
https://chatgpt.com/codex/tasks/task_e_68e2839c9e948325aea7e68c410255bb