### PR TITLE
Tighten risk validation and stop-loss handling

### DIFF
--- a/dynamicRiskModel.js
+++ b/dynamicRiskModel.js
@@ -272,12 +272,19 @@ export function realTimeRiskController({
   exchangeMarginMultiplier = 1,
   utilizationCap,
   lotSize,
+  tickSize,
   slippage = 0,
   spread = 0,
   costBuffer = 1,
 }) {
   let stopLoss = calculateDynamicStopLoss({ atr, entry, direction });
-  stopLoss = adjustStopLoss({ price: entry, stopLoss, direction, atr });
+  stopLoss = adjustStopLoss({
+    price: entry,
+    stopLoss,
+    direction,
+    atr,
+    tickSize,
+  });
   const qty = calculateLotSize({
     capital,
     riskAmount: risk,
@@ -322,6 +329,7 @@ export function backtestRiskModel(data = [], { capital = 100000, risk = 0.01 } =
       capital: balance,
       risk,
       lotSize: d.lotSize,
+      tickSize: d.tickSize,
       slippage: rowSlippage,
       spread: rowSpread,
       costBuffer: rowCostBuffer,

--- a/positionSizing.js
+++ b/positionSizing.js
@@ -382,6 +382,7 @@ export function calculatePositionSize({
  * @param {number} [opts.slippage]  Expected slippage per unit
  * @param {number} [opts.spread]    Current bid/ask spread
  * @param {number} [opts.costBuffer] Buffer for taxes and slippage
+ * @param {number} [opts.tickSize]  Instrument tick size for price snapping
  * @param {number} [opts.riskPercent=0.01] Risk per trade as a fraction of capital
  * @returns {Object} { stopLoss, qty, target1, target2 }
  */
@@ -397,6 +398,7 @@ export function calculateTradeParameters({
   slippage = 0,
   spread = 0,
   costBuffer = 1,
+  tickSize,
   riskPercent = 0.01,
 }) {
   const dynamicSL = calculateDynamicStopLoss({ atr, entry, direction });
@@ -426,10 +428,12 @@ export function calculateTradeParameters({
     stopLoss: finalSL,
     direction,
     atr,
+    tickSize,
   });
 
   const rawRisk = Math.abs(entry - finalSL);
-  const effectiveRisk = rawRisk + slippage + spread;
+  const buffer = Number.isFinite(costBuffer) && costBuffer > 0 ? costBuffer : 1;
+  const effectiveRisk = (rawRisk + slippage + spread) * buffer;
   const riskAmount = capital * riskPercent;
   let qty = calculatePositionSize({
     capital,
@@ -443,7 +447,7 @@ export function calculateTradeParameters({
     utilizationCap: 1,
     leverage,
     marginPercent,
-    costBuffer,
+    costBuffer: buffer,
     slippage,
     spread,
   });

--- a/riskConfig.js
+++ b/riskConfig.js
@@ -41,9 +41,33 @@ const configuredDefaults = {
   minRR: num(process.env.MIN_RR),
 };
 
-export const riskDefaults = Object.freeze(
-  Object.fromEntries(
-    Object.entries(configuredDefaults).filter(([, value]) => value !== undefined)
-  )
-);
+const prune = (obj = {}) =>
+  Object.fromEntries(Object.entries(obj).filter(([, value]) => value !== undefined));
+
+const nestedDefaults = {
+  market: {
+    maxAtrMult: num(process.env.MARKET_MAX_ATR_MULT),
+    maxLatencyMs: num(process.env.MARKET_MAX_LATENCY_MS),
+  },
+  sl: {
+    minAtrMult: num(process.env.SL_MIN_ATR_MULT),
+    maxAtrMult: num(process.env.SL_MAX_ATR_MULT),
+  },
+};
+
+const flatDefaults = prune(configuredDefaults);
+
+export const riskDefaults = Object.freeze({
+  market: {
+    maxAtrMult: 1.5,
+    maxLatencyMs: 120_000,
+    ...prune(nestedDefaults.market),
+  },
+  sl: {
+    minAtrMult: 0.5,
+    maxAtrMult: 3,
+    ...prune(nestedDefaults.sl),
+  },
+  ...flatDefaults,
+});
 

--- a/riskEngine.js
+++ b/riskEngine.js
@@ -592,6 +592,19 @@ export function isSignalValid(signal, ctx = {}) {
     stopLoss: signal.stopLoss,
     target: signal.target2 ?? signal.target,
     winrate: ctx.winrate || 0,
+    slippage: signal.slippage ?? ctx.slippage ?? 0,
+    spread: signal.spread ?? ctx.spread ?? 0,
+    costBuffer:
+      (Number.isFinite(ctx.costBuffer) && ctx.costBuffer > 0 && ctx.costBuffer) ||
+      (Number.isFinite(signal.costBufferApplied)
+        ? signal.costBufferApplied
+        : Number.isFinite(signal.costBuffer)
+        ? signal.costBuffer
+        : Number.isFinite(riskState.config?.costBuffer)
+        ? riskState.config.costBuffer
+        : Number.isFinite(riskDefaults.costBuffer)
+        ? riskDefaults.costBuffer
+        : 1),
   });
   if (!rr.valid)
     return recordRejection(rr.reason ?? "rrBelowMinimum", {
@@ -627,6 +640,8 @@ export function isSignalValid(signal, ctx = {}) {
       entry: signal.entry,
       stopLoss: signal.stopLoss,
       atr: Number.isFinite(signal.atr) ? signal.atr : undefined,
+      minMult: riskDefaults?.sl?.minAtrMult ?? 0.5,
+      maxMult: riskDefaults?.sl?.maxAtrMult ?? 3,
     })
   )
     return recordRejection("atrStopLossInvalid");
@@ -641,6 +656,7 @@ export function isSignalValid(signal, ctx = {}) {
       stopLoss: signal.stopLoss,
       atr: Number.isFinite(signal.atr) ? signal.atr : undefined,
       structureBreak: ctx.structureBreak,
+      direction: signal.direction,
     })
   )
     return recordRejection("slInvalid", {

--- a/riskValidator.js
+++ b/riskValidator.js
@@ -2,6 +2,7 @@
 // Provides pre-execution risk validation utilities
 import { logSignalRejected } from './auditLogger.js';
 import { toISTDate } from './util.js';
+import { riskDefaults } from './riskConfig.js';
 
 function resolveStrategyCategory(name = '') {
   const s = String(name).toLowerCase();
@@ -38,8 +39,18 @@ export function getMinRRForStrategy(strategy, winrate = 0) {
   }
 }
 
-export function validateRR({ strategy, entry, stopLoss, target, winrate = 0 }) {
-  const risk = Math.abs(entry - stopLoss);
+export function validateRR({
+  strategy,
+  entry,
+  stopLoss,
+  target,
+  winrate = 0,
+  slippage = 0,
+  spread = 0,
+  costBuffer = 1,
+}) {
+  const raw = Math.abs(entry - stopLoss);
+  const risk = Math.max((raw + slippage + spread) * (costBuffer || 1), 1e-6);
   if (!risk) return { valid: false, rr: 0, minRR: Infinity };
   const rr = Math.abs((target - entry) / risk);
   const minRR = getMinRRForStrategy(strategy, winrate);
@@ -52,29 +63,61 @@ export function validateRR({ strategy, entry, stopLoss, target, winrate = 0 }) {
   return { valid: true, rr, minRR };
 }
 
-export function adjustStopLoss({ price, stopLoss, direction, atr, structureBreak = false }) {
+const snapToTick = (v, tickSize) => {
+  if (!tickSize || tickSize <= 0) return v;
+  const n = Math.round(v / tickSize) * tickSize;
+  return Number(n.toFixed(8));
+};
+
+export function adjustStopLoss({
+  price,
+  stopLoss,
+  direction,
+  atr,
+  structureBreak = false,
+  tickSize,
+  minAtrMult = 0.25,
+  maxAtrMult = 4,
+}) {
+  if (!Number.isFinite(price) || !Number.isFinite(stopLoss)) return stopLoss;
   let newSL = stopLoss;
-  const safeAtr = Number.isFinite(atr) ? atr : price * 0.005;
-  const thresh = safeAtr * 0.5;
+  const safeAtr = Number.isFinite(atr) ? atr : Math.max(price * 0.005, 0.01);
+  const minDist = safeAtr * minAtrMult;
+  const maxDist = safeAtr * maxAtrMult;
+
   if (structureBreak) {
-    return direction === 'Long' ? Math.max(stopLoss, price) : Math.min(stopLoss, price);
+    newSL = direction === 'Long' ? price - minDist : price + minDist;
+    return snapToTick(newSL, tickSize);
   }
-  if (direction === 'Long') {
-    if (price - stopLoss > thresh) {
-      newSL = Math.max(stopLoss, price - thresh);
-    }
-  } else {
-    if (stopLoss - price > thresh) {
-      newSL = Math.min(stopLoss, price + thresh);
-    }
+
+  if (direction === 'Long' && newSL >= price) newSL = price - minDist;
+  if (direction === 'Short' && newSL <= price) newSL = price + minDist;
+
+  const dist = Math.abs(price - newSL);
+  if (dist < minDist) {
+    newSL = direction === 'Long' ? price - minDist : price + minDist;
+  } else if (dist > maxDist) {
+    newSL = direction === 'Long' ? price - maxDist : price + maxDist;
   }
+
+  newSL = snapToTick(newSL, tickSize);
   return newSL;
 }
 
-export function isSLInvalid({ price, stopLoss, atr, structureBreak = false }) {
-  // we don't auto-invalidate on structureBreak; SL is validated by distance
+export function isSLInvalid({
+  price,
+  stopLoss,
+  atr,
+  structureBreak = false,
+  direction,
+  tickSize,
+}) {
+  if (!Number.isFinite(price) || !Number.isFinite(stopLoss)) return true;
+  if (direction === 'Long' && stopLoss >= price) return true;
+  if (direction === 'Short' && stopLoss <= price) return true;
+  const safeAtr = Number.isFinite(atr) ? atr : Math.max(price * 0.005, 0.01);
   const proximity = Math.abs(price - stopLoss);
-  return proximity <= atr * 0.2;
+  return proximity <= safeAtr * 0.2;
 }
 
 // Ensure stop-loss distance is sensible relative to ATR
@@ -192,9 +235,11 @@ export function checkMarketConditions({
   newsImpact = false,
   eventActive = false,
 }) {
-  if (avgAtr && atr > avgAtr * 1.5) return false;
+  const atrMult = riskDefaults?.market?.maxAtrMult ?? 1.5;
+  const maxLatencyMs = riskDefaults?.market?.maxLatencyMs ?? 2 * 60 * 1000;
+  if (avgAtr && atr > avgAtr * atrMult) return false;
   if (indexTrend && signalDirection && indexTrend !== signalDirection) return false;
-  if (timeSinceSignal > 2 * 60 * 1000) return false;
+  if (timeSinceSignal > maxLatencyMs) return false;
   if (typeof spread === 'number') {
     let spreadLimit = computeSpreadLimit({ price, maxSpread, maxSpreadPct });
     if (spreadLimit == null) spreadLimit = 0.3; // final fallback
@@ -244,6 +289,9 @@ export function validatePreExecution(signal, market) {
     stopLoss: signal.stopLoss,
     target: signal.target2,
     winrate: market.winrate || 0,
+    slippage: signal.slippage || market.slippage || 0,
+    spread: signal.spread ?? market.spread ?? 0,
+    costBuffer: market.costBuffer || 1,
   });
   if (!rrInfo.valid) {
     console.log(
@@ -264,6 +312,7 @@ export function validatePreExecution(signal, market) {
       stopLoss: signal.stopLoss,
       atr: signal.atr,
       structureBreak: market.structureBreak,
+      direction: signal.direction,
     })
   ) {
     console.log(`[RISK] ${signal.stock || signal.symbol} stop-loss invalid`);
@@ -274,6 +323,45 @@ export function validatePreExecution(signal, market) {
       signal
     );
     return false;
+  }
+
+  if (
+    !validateATRStopLoss({
+      entry: signal.entry,
+      stopLoss: signal.stopLoss,
+      atr: signal.atr,
+      minMult: riskDefaults?.sl?.minAtrMult ?? 0.5,
+      maxMult: riskDefaults?.sl?.maxAtrMult ?? 3,
+    })
+  ) {
+    console.log(`[RISK] ${signal.stock || signal.symbol} SL outside ATR bounds`);
+    logSignalRejected(
+      signal.signalId || signal.algoSignal?.signalId,
+      'atrSLInvalid',
+      { entry: signal.entry, stopLoss: signal.stopLoss, atr: signal.atr },
+      signal
+    );
+    return false;
+  }
+
+  if (market?.support != null || market?.resistance != null) {
+    const ok = validateSupportResistance({
+      entry: market.currentPrice ?? signal.entry,
+      direction: signal.direction,
+      support: market.support,
+      resistance: market.resistance,
+      atr: signal.atr,
+    });
+    if (!ok) {
+      console.log(`[RISK] ${signal.stock || signal.symbol} too close to S/R`);
+      logSignalRejected(
+        signal.signalId || signal.algoSignal?.signalId,
+        'srProximity',
+        { support: market.support, resistance: market.resistance },
+        signal
+      );
+      return false;
+    }
   }
 
   if (

--- a/scanner.js
+++ b/scanner.js
@@ -673,6 +673,12 @@ export async function rankAndExecute(signals = []) {
       maxSpreadPct: FILTERS.maxSpreadPct,
       winrate:
         marketContext?.strategyWinrates?.[top.strategy] ?? marketContext?.winrate ?? 0,
+      costBuffer:
+        top.costBufferApplied ?? top.costBuffer ?? marketContext?.costBuffer ?? riskDefaults.costBuffer,
+      slippage: top.slippage ?? marketContext?.slippage ?? 0,
+      spread: top.spread ?? marketContext?.spread ?? 0,
+      support: top.support,
+      resistance: top.resistance,
     });
     if (!ok) return null;
     const requiredMargin = calculateRequiredMargin({

--- a/strategyEngine.js
+++ b/strategyEngine.js
@@ -618,5 +618,14 @@ export function evaluateAllStrategies(context = {}) {
   ];
   return strategies
     .map((fn) => fn(base))
-    .filter(Boolean);
+    .filter(Boolean)
+    .map((signal) => {
+      if (!signal || typeof signal !== 'object') return signal;
+      const tickSize = base.tickSize ?? base.tick ?? base.tick_size ?? signal.tickSize;
+      const lotSize = base.lotSize ?? base.contractSize ?? signal.lotSize;
+      const enriched = { ...signal };
+      if (tickSize !== undefined) enriched.tickSize = tickSize;
+      if (lotSize !== undefined) enriched.lotSize = lotSize;
+      return enriched;
+    });
 }


### PR DESCRIPTION
## Summary
- enforce friction-aware risk/reward checks, stop-loss side validation, tick snapping, and ATR/S/R guards before execution
- expose market-volatility and stop-loss ATR thresholds through riskConfig for easier tuning
- propagate tick size and friction inputs through sizing, dynamic risk, and scanner flows so stops stay broker-valid

## Testing
- npm test *(fails: missing applyRealizedPnL export and upstream data dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e289775c708325a19dcf68dba37ab5