### PR TITLE
Improve EMA caching and VWAP configuration

### DIFF
--- a/strategies.js
+++ b/strategies.js
@@ -465,6 +465,8 @@ export function detectAndScorePattern(
       only: ["ema9", "ema21", "ema200", "rsi", "atr", "macd", "macdHist", "vwap"],
       benchmarkCloses: context.benchmarkCloses,
       rsLookback: context.rsLookback ?? 20,
+      vwapMode: (config?.vwapMode) || "rolling",
+      vwapWindow: 10,
     });
   if (!featureSet) return null;
 
@@ -2023,6 +2025,8 @@ export function evaluateStrategies(
       ],
       benchmarkCloses: context.benchmarkCloses,
       rsLookback: context.rsLookback ?? 20,
+      vwapMode: (cfg?.vwapMode) || "rolling",
+      vwapWindow: 10,
     }) || {};
   const atrCandidate =
     options?.atr ??


### PR DESCRIPTION
## Summary
- fix the EMA cache to handle non-append updates and cap the cache size
- add configurable VWAP mode/window and gate heavy features behind `only`
- pass VWAP mode options through the strategy feature computation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2b1663afc8325bff1ea4760756b2f