### PR TITLE
Align VWAP options and candle utilities

### DIFF
--- a/scanner.js
+++ b/scanner.js
@@ -1,6 +1,6 @@
 // scanner.js
 
-import { computeFeatures } from "./featureEngine.js";
+import { computeFeatures, resetIndicatorCache } from "./featureEngine.js";
 import {
   debounceSignal,
   calculateExpiryMinutes,
@@ -72,6 +72,8 @@ const FILTERS = {
   maxSpreadPct: MODE === "strict" ? 0.3 : 0.5,
 };
 
+let lastFeatureSeriesKey = null;
+
 function logError(context, err) {
   console.error(
     `[${new Date().toISOString()}] ❌ [${context}] ${err?.message || err}`
@@ -124,8 +126,13 @@ export async function analyzeCandles(
       marketContext?.benchmark?.[symbol] ??
       marketContext?.benchmarks?.[symbol] ??
       null;
+    const seriesKey = symbol ? `${symbol}:primary` : null;
+    if (seriesKey && seriesKey !== lastFeatureSeriesKey) {
+      resetIndicatorCache();
+      lastFeatureSeriesKey = seriesKey;
+    }
     const features = computeFeatures(cleanCandles, {
-      seriesKey: symbol ? `${symbol}:primary` : null,
+      seriesKey,
       supertrendSettings: { atrLength: 10, multiplier: 3 },
       only: [
         "ema9",

--- a/strategyEngine.js
+++ b/strategyEngine.js
@@ -298,6 +298,7 @@ export function strategyTripleTop(context = {}) {
     spread = 0,
     liquidity = 0,
     atr: contextAtr,
+    config: contextConfig,
   } = context;
   const cleanCandles = Array.isArray(candles)
     ? context.__sanitizedCandles
@@ -306,17 +307,25 @@ export function strategyTripleTop(context = {}) {
     : [];
   if (!Array.isArray(cleanCandles) || cleanCandles.length < 7) return null;
 
+  const cfg = contextConfig || {};
+  const vwapMode = cfg?.vwapMode || 'rolling';
+  const vwapWindow = cfg?.vwapWindow ?? 20;
   const seriesKey = buildSeriesKey(context, 'tripleTop');
   const featureSet =
     features ??
     computeFeatures(cleanCandles, {
       seriesKey,
       supertrendSettings: DEFAULT_SUPERTREND_SETTINGS,
+      vwapMode,
+      vwapWindow,
     });
   if (!featureSet) return null;
 
   const atr = (contextAtr ?? featureSet?.atr ?? getATR(cleanCandles, 14)) ?? 0;
-  const patterns = detectAllPatterns(cleanCandles, atr, 5);
+  const patterns = detectAllPatterns(cleanCandles, atr, 5, {
+    vwapMode,
+    vwapWindow,
+  });
   const tripleTop = patterns.find(p => p.type === 'Triple Top');
   if (!tripleTop) return null;
 
@@ -368,6 +377,7 @@ export function strategyVWAPReversal(context = {}) {
     spread = 0,
     liquidity = 0,
     atr: contextAtr,
+    config: contextConfig,
   } = context;
   const cleanCandles = Array.isArray(candles)
     ? context.__sanitizedCandles
@@ -376,17 +386,25 @@ export function strategyVWAPReversal(context = {}) {
     : [];
   if (!Array.isArray(cleanCandles) || cleanCandles.length < 5) return null;
 
+  const cfg = contextConfig || {};
+  const vwapMode = cfg?.vwapMode || 'rolling';
+  const vwapWindow = cfg?.vwapWindow ?? 20;
   const seriesKey = buildSeriesKey(context, 'vwap');
   const featureSet =
     features ??
     computeFeatures(cleanCandles, {
       seriesKey,
       supertrendSettings: DEFAULT_SUPERTREND_SETTINGS,
+      vwapMode,
+      vwapWindow,
     });
   if (!featureSet) return null;
 
   const atr = (contextAtr ?? featureSet?.atr ?? getATR(cleanCandles, 14)) ?? 0;
-  const patterns = detectAllPatterns(cleanCandles, atr, 5);
+  const patterns = detectAllPatterns(cleanCandles, atr, 5, {
+    vwapMode,
+    vwapWindow,
+  });
   const pattern = patterns.find(p => p.type === 'VWAP Reversal');
   if (!pattern) return null;
 
@@ -442,6 +460,7 @@ export function patternBasedStrategy(context = {}) {
     spread = 0,
     liquidity = 0,
     atr: contextAtr,
+    config: contextConfig,
   } = context;
   const cleanCandles = Array.isArray(candles)
     ? context.__sanitizedCandles
@@ -450,17 +469,25 @@ export function patternBasedStrategy(context = {}) {
     : [];
   if (!Array.isArray(cleanCandles) || cleanCandles.length < 5) return null;
 
+  const cfg = contextConfig || {};
+  const vwapMode = cfg?.vwapMode || 'rolling';
+  const vwapWindow = cfg?.vwapWindow ?? 20;
   const seriesKey = buildSeriesKey(context, 'pattern');
   const featureSet =
     features ??
     computeFeatures(cleanCandles, {
       seriesKey,
       supertrendSettings: DEFAULT_SUPERTREND_SETTINGS,
+      vwapMode,
+      vwapWindow,
     });
   if (!featureSet) return null;
 
   const atr = (contextAtr ?? featureSet?.atr ?? getATR(cleanCandles, 14)) ?? 0;
-  const patterns = detectAllPatterns(cleanCandles, atr, 5);
+  const patterns = detectAllPatterns(cleanCandles, atr, 5, {
+    vwapMode,
+    vwapWindow,
+  });
   if (!patterns || patterns.length === 0) return null;
 
   let best = null;


### PR DESCRIPTION
## Summary
- deduplicate sorted candles, harden kite-backed MA lookups, and preserve timestamps when aggregating bars
- add VWAP mode/window controls to pattern detection and propagate options through strategy helpers
- reset cached indicators when switching scanner series keys for more reliable feature recomputation

## Testing
- npm test *(fails: missing exports in existing test harness and external Kite session requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68e32644c2a48325a2d8d5435a452dd5