### PR TITLE
Inject deterministic clock pattern into time-dependent modules

### DIFF
--- a/tests/exitManager.test.js
+++ b/tests/exitManager.test.js
@@ -8,9 +8,16 @@ const {
   forceTimeExit,
   detectReversalExit,
   checkExitConditions,
+  setExitClock,
+  resetExitClock,
+  shouldExit,
 } = mod;
 
 setTrailingPercent(10); // easier to test
+
+test.after(() => {
+  resetExitClock();
+});
 
 test('applyTrailingSL updates stop and signals exit', () => {
   const pos = { side: 'Long', entryPrice: 100, stopLoss: 95, lastPrice: 110 };
@@ -22,8 +29,9 @@ test('applyTrailingSL updates stop and signals exit', () => {
   assert.equal(exit, true);
 });
 
-test('forceTimeExit triggers after maxHoldMs', () => {
-  const pos = { openTime: Date.now() - 6000, maxHoldMs: 5000 };
+test('forceTimeExit triggers after maxHoldMs using injected clock', () => {
+  setExitClock({ now: () => 10_000 });
+  const pos = { openTime: 4_000, maxHoldMs: 5_000 };
   assert.equal(forceTimeExit(pos), true);
 });
 
@@ -36,4 +44,9 @@ test('checkExitConditions returns first matching reason', () => {
   const pos = { side: 'Long', entryPrice: 100, stopLoss: 90, lastPrice: 80 };
   const res = checkExitConditions(pos);
   assert.deepEqual(res, { shouldExit: true, reason: 'TrailingStop' });
+});
+
+test('shouldExit respects expiry with injected clock', () => {
+  setExitClock({ now: () => 2_000 });
+  assert.equal(shouldExit({ direction: 'Long', stopLoss: 95, expiresAt: new Date(1_000).toISOString() }, 100), true);
 });

--- a/tests/signalLifecycle.test.js
+++ b/tests/signalLifecycle.test.js
@@ -5,33 +5,44 @@ const auditMock = test.mock.module('../auditLogger.js', {
   namedExports: { logSignalExpired: () => {}, logSignalMutation: () => {} }
 });
 const dbMock = test.mock.module('../db.js', {
-  defaultExport: { collection: () => ({ updateOne: async () => {} }) },
+  defaultExport: {
+    collection: () => ({
+      updateOne: async () => {},
+      insertOne: async () => ({ acknowledged: true, insertedId: 'mock-id' }),
+    }),
+  },
   namedExports: { connectDB: async () => ({}) }
 });
 
-const { addSignal, activeSignals, checkExpiries } = await import('../signalManager.js');
+const { addSignal, activeSignals, checkExpiries, setSignalManagerClock, resetSignalManagerClock } = await import('../signalManager.js');
 
 auditMock.restore();
 dbMock.restore();
 process.env.NODE_ENV = 'test';
 
-activeSignals.clear();
+test.after(() => {
+  resetSignalManagerClock();
+});
 
-const now = Date.now();
+activeSignals.clear();
+setSignalManagerClock({ now: () => 10_000 });
+
 const signal = {
   stock: 'TEST',
   direction: 'Long',
-  expiresAt: new Date(now + 1000).toISOString(),
+  expiresAt: new Date(11_000).toISOString(),
   confidence: 1,
-  signalId: 'sig1',
 };
 
-await addSignal(signal);
+const created = await addSignal(signal);
+await checkExpiries(12_000);
 
-await checkExpiries(now + 2000);
+test('signal id generation uses injected clock', () => {
+  assert.equal(created.signalId, 'TEST-10000');
+});
 
 test('signal expires after expiry time', () => {
   const sigMap = activeSignals.get('TEST');
-  const info = sigMap.get('sig1');
+  const info = sigMap.get(created.signalId);
   assert.equal(info.status, 'expired');
 });

--- a/tradeLifecycle.js
+++ b/tradeLifecycle.js
@@ -8,6 +8,21 @@ import {
   resolveSignalConflicts,
   openPositions,
 } from './portfolioContext.js';
+import { ensureClock } from './src/backtest/clock.js';
+
+let activeClock = ensureClock();
+
+function nowMs() {
+  return activeClock.now();
+}
+
+export function setTradeLifecycleClock(clockLike) {
+  activeClock = ensureClock(clockLike);
+}
+
+export function resetTradeLifecycleClock() {
+  activeClock = ensureClock();
+}
 
 /**
  * Wait for an order to be filled by polling getAllOrders()
@@ -17,8 +32,8 @@ import {
  * @returns {Promise<boolean>} fill status
  */
 export async function waitForOrderFill(orderId, timeout = 30000, interval = 1000) {
-  const start = Date.now();
-  while (Date.now() - start < timeout) {
+  const start = nowMs();
+  while (nowMs() - start < timeout) {
     const orders = await getAllOrders();
     const ord = orders.find((o) => o.order_id === orderId);
     if (ord && ord.status === 'COMPLETE') return true;
@@ -183,4 +198,3 @@ export async function executeSignal(signal, opts = {}) {
     targetId: targetOrder.order_id,
   };
 }
-


### PR DESCRIPTION
### Motivation
- Make backtests and unit tests deterministic by replacing ad-hoc `Date.now()` usage with an injectable clock across core time-dependent modules.
- Provide a reusable pattern so Phase 2 (Deterministic + reusable) can be completed and other modules can be migrated incrementally.

### Description
- Added clock injection via `ensureClock` and module-scoped `nowMs()`/`nowDate()` helpers and exposed setters/resetters in `exitManager`, `tradeLifecycle`, `signalManager`, and `portfolioContext` so tests/backtests can control time (`setExitClock`, `setTradeLifecycleClock`, `setSignalManagerClock`, `setPortfolioClock` and corresponding `reset*` functions).
- Replaced direct system time calls with the injected clock in key code paths: expiry and stop checks (`forceTimeExit`, `shouldExit`), order-fill waiting (`waitForOrderFill`), signal default expiry/id generation/DB timestamps, and re-entry gating / position timestamps.
- Updated unit tests to assert deterministic behavior under injected clocks: `tests/exitManager.test.js`, `tests/portfolioContext.test.js`, and `tests/signalLifecycle.test.js` now exercise the injected-clock APIs and deterministic id/expiry behavior.
- Kept default behavior unchanged by using `ensureClock()` defaulting to system time when no test/backtest clock is provided.

### Testing
- Performed syntax/type checks with `node --check exitManager.js && node --check tradeLifecycle.js && node --check signalManager.js && node --check portfolioContext.js`, which succeeded.
- Ran the repository test runner with `npm test`, which failed due to pre-existing repository/environment issues (unrelated export mismatches and external Mongo/Kite connectivity/DNS errors) rather than the changes in this PR.
- Executed focused test runs for the modified modules (`node --test --experimental-test-module-mocks tests/exitManager.test.js tests/portfolioContext.test.js tests/signalLifecycle.test.js tests/tradeLifecycle.test.js`), which exercised the new clock APIs but encountered external environment failures (Mongo DNS, some unrelated module export mismatches) that prevented a clean full pass; the modified files themselves load and the new deterministic paths are covered by the updated tests.

Remaining work after this PR
- Migrate other direct-time consumers (examples: `aligner.js`, `orderExecution.js`, `signalRanker.js`, `scanner.js`, and parts of `kite.js`) to the same injected-clock pattern for complete Phase 2 coverage.
- Phase 3 (historical options-chain snapshot provider/downloader and optional Black‑Scholes greeks) and Phase 4 (execution realism: spread curves, latency, partial fills, conservative candle-paths, live-vs-backtest reconciliation) remain pending and out of scope for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69915cc4b0a08325b5d326ecef0d2545)